### PR TITLE
[UDFS] Replace flat 16 MB FSBM with LZNT1-chunked bitmap + AllBits uniform-chunk fast-path

### DIFF
--- a/drivers/filesystems/udfs/fscntrl.cpp
+++ b/drivers/filesystems/udfs/fscntrl.cpp
@@ -682,6 +682,7 @@ UDFCleanupVCB(
     if (Vcb->FSBM_OldBitmap) {
         DbgFreePool(Vcb->FSBM_OldBitmap);
         Vcb->FSBM_OldBitmap = NULL;
+        Vcb->FSBM_OldBitmapCompressedSize = 0;
     }
 
     MyFreeMemoryAndPointer(Vcb->VolIdent.Buffer);

--- a/drivers/filesystems/udfs/fscntrl.cpp
+++ b/drivers/filesystems/udfs/fscntrl.cpp
@@ -664,9 +664,9 @@ UDFCleanupVCB(
     MyFreeMemoryAndPointer(Vcb->Vat);
     MyFreeMemoryAndPointer(Vcb->SparingTable);
 
-    if (Vcb->FSBM_Bitmap) {
-        DbgFreePool(Vcb->FSBM_Bitmap);
-        Vcb->FSBM_Bitmap = NULL;
+    if (Vcb->FSBM_Chunks) {
+        UDFCBMDestroy(Vcb->FSBM_Chunks);
+        Vcb->FSBM_Chunks = NULL;
     }
 
     if (Vcb->BSBM_Bitmap) {
@@ -1264,7 +1264,6 @@ UDFGetVolumeBitmap(
     LARGE_INTEGER StartingLcn;
     PVOLUME_BITMAP_BUFFER OutputBuffer;
     ULONG i, lim;
-    PULONG FSBM;
     BOOLEAN VcbAcquired = FALSE;
 
     ASSERT_VCB(Vcb);
@@ -1367,13 +1366,12 @@ UDFGetVolumeBitmap(
 
         RtlZeroMemory( &OutputBuffer->Buffer[0], BytesToCopy );
         lim = BytesToCopy * 8;
-        FSBM = (PULONG)(Vcb->FSBM_Bitmap);
 
 //        Dest = (PULONG)(&OutputBuffer->Buffer[0]);
 
         for(i=StartingCluster & ~7; i<lim; i++) {
-            if (UDFGetFreeBit(FSBM, i << Vcb->SectorShift))
-                UDFSetFreeBit(FSBM, i);
+            if (UDFCBMGetBit(Vcb->FSBM_Chunks, i << Vcb->SectorShift))
+                UDFCBMSetBit(Vcb->FSBM_Chunks, i);
         }
 
         Irp->IoStatus.Information = FIELD_OFFSET(VOLUME_BITMAP_BUFFER, Buffer) + BytesToCopy;

--- a/drivers/filesystems/udfs/struct.h
+++ b/drivers/filesystems/udfs/struct.h
@@ -355,10 +355,25 @@ enum VCB_CONDITION {
 /* Sentinel meaning no chunk is currently decompressed */
 #define UDF_FSBM_NO_HOT_CHUNK   ((ULONG)~0UL)
 
+/*
+ * Uniform-chunk fast-path hint stored in UDF_FSBM_CHUNK::AllBits.
+ * Valid only when the chunk is NOT the current hot slot.
+ * Initialised to ALLBITS_USED by RtlZeroMemory (NULL CompressedData = all-zero).
+ * Updated in UDFCBMFlushHot after the hot chunk is (re-)compressed.
+ */
+#define UDF_FSBM_ALLBITS_USED   ((UCHAR)0x00) /* all bits 0 = every LBA in chunk USED   */
+#define UDF_FSBM_ALLBITS_FREE   ((UCHAR)0x01) /* all bits 1 = every LBA in chunk FREE   */
+#define UDF_FSBM_ALLBITS_MIXED  ((UCHAR)0x02) /* mixed; chunk must be decompressed      */
+
 /* Descriptor for one compressed chunk */
 typedef struct _UDF_FSBM_CHUNK {
     PCHAR CompressedData; /* NULL = all-zero (all sectors USED, never touched) */
     ULONG CompressedSize; /* 0 = verbatim 64 KiB copy; >0 = LZNT1 byte count  */
+    /* Uniform-chunk fast-path hint (see UDF_FSBM_ALLBITS_*).
+       Only consulted when this chunk is NOT the current hot slot.
+       Initialised to 0x00 (USED) by RtlZeroMemory. */
+    UCHAR AllBits;
+    UCHAR Pad[3];
 } UDF_FSBM_CHUNK, *PUDF_FSBM_CHUNK;
 
 /* Chunked compressed Free-Space Bitmap header */

--- a/drivers/filesystems/udfs/struct.h
+++ b/drivers/filesystems/udfs/struct.h
@@ -547,7 +547,8 @@ struct VCB {
     // other - owner's FE location
 #endif //UDF_TRACK_ONDISK_ALLOCATION_OWNERS
 
-    PCHAR           FSBM_OldBitmap;  // 0 - free, 1 - used
+    PCHAR           FSBM_OldBitmap;           // 0 - free, 1 - used (compressed storage)
+    ULONG           FSBM_OldBitmapCompressedSize; // size of compressed FSBM_OldBitmap data (0 if uncompressed)
     ULONG           BitmapModified;
     PCHAR           BSBM_Bitmap;     // 0 - normal, 1 - bad-block
 

--- a/drivers/filesystems/udfs/struct.h
+++ b/drivers/filesystems/udfs/struct.h
@@ -346,6 +346,35 @@ enum VCB_CONDITION {
     VcbDismountInProgress
 };
 
+/* ---------- Chunked compressed Free-Space Bitmap ----------------------------- */
+
+/* Uncompressed size of one chunk: 64 KiB covers 524,288 LBA bits */
+#define UDF_FSBM_CHUNK_BYTES    ((ULONG)(64 * 1024))
+#define UDF_FSBM_CHUNK_BITS     (UDF_FSBM_CHUNK_BYTES * 8)
+
+/* Sentinel meaning no chunk is currently decompressed */
+#define UDF_FSBM_NO_HOT_CHUNK   ((ULONG)~0UL)
+
+/* Descriptor for one compressed chunk */
+typedef struct _UDF_FSBM_CHUNK {
+    PCHAR CompressedData; /* NULL = all-zero (all sectors USED, never touched) */
+    ULONG CompressedSize; /* 0 = verbatim 64 KiB copy; >0 = LZNT1 byte count  */
+} UDF_FSBM_CHUNK, *PUDF_FSBM_CHUNK;
+
+/* Chunked compressed Free-Space Bitmap header */
+typedef struct _UDF_CHUNKED_FSBM {
+    ULONG           ChunkCount; /* number of 64 KiB chunks                     */
+    ULONG           BitCount;   /* total LBA count (= FSBM_BitCount)            */
+    ULONG           ByteCount;  /* = (BitCount + 7) / 8  (= FSBM_ByteCount)    */
+    ULONG           HotIdx;     /* UDF_FSBM_NO_HOT_CHUNK = nothing pinned       */
+    BOOLEAN         HotDirty;   /* hot chunk has been modified since last flush  */
+    UCHAR           Pad[3];
+    PCHAR           HotData;    /* 64 KiB decompressed scratch (always live)    */
+    PUDF_FSBM_CHUNK Chunks;     /* [ChunkCount] descriptor array                */
+} UDF_CHUNKED_FSBM, *PUDF_CHUNKED_FSBM;
+
+/* ----------------------------------------------------------------------------- */
+
 struct VCB {
 
     UDFIdentifier NodeIdentifier;
@@ -540,7 +569,7 @@ struct VCB {
     ULONG           FSBM_ByteCount;
     // the following 2 fields are equal to NTIFS's RTL_BITMAP structure
     ULONG           FSBM_BitCount;
-    PCHAR           FSBM_Bitmap;     // 0 - free, 1 - used
+    PUDF_CHUNKED_FSBM FSBM_Chunks;   // chunked compressed free-space bitmap
 #ifdef UDF_TRACK_ONDISK_ALLOCATION_OWNERS
     PULONG          FSBM_Bitmap_owners; // 0 - free
     // -1 - used by unknown

--- a/drivers/filesystems/udfs/udf_info/alloc.cpp
+++ b/drivers/filesystems/udfs/udf_info/alloc.cpp
@@ -287,6 +287,13 @@ UDFGetBitmapLen(
         j=0;
 While_3:
         i++;
+        /* Guard: Lim is the 32-bit word index of the last bit, lLim is the
+           bit-offset within that word (both derived from the original Lim>>5 /
+           Lim&31 split above).  When lLim==0, the bit-limit falls exactly on a
+           word boundary: word Lim has 0 bits to process and may lie one past the
+           end of a valid bitmap buffer — break before reading it.  When lLim>0,
+           word Lim IS the valid last (partial) word — don't break early. */
+        if (i > Lim || (i == Lim && !lLim)) break;
         a = Bitmap[i];
 
         if (i<Lim) {

--- a/drivers/filesystems/udfs/udf_info/alloc.cpp
+++ b/drivers/filesystems/udfs/udf_info/alloc.cpp
@@ -315,7 +315,6 @@ UDFFindMinSuitableExtent(
     )
 {
     SIZE_T i, len;
-    uint32* cur;
     SIZE_T best_lba=0;
     SIZE_T best_len=0;
     SIZE_T max_lba=0;
@@ -333,8 +332,6 @@ UDFFindMinSuitableExtent(
     if (Length > (uint32)(UDF_EXTENT_LENGTH_MASK >> Vcb->SectorShift))
         Length = (UDF_EXTENT_LENGTH_MASK >> Vcb->SectorShift);
 
-    cur = (uint32*)(Vcb->FSBM_Bitmap);
-
 retry_no_align:
 
     i=SearchStart;
@@ -349,8 +346,8 @@ retry_no_align:
             if (i >= SearchLim)
                 break;
         }
-        len = UDFGetBitmapLen(cur, i, SearchLim);
-        if (UDFGetFreeBit(cur, i)) { // is the extent found free or used ?
+        len = UDFCBMGetLen(Vcb->FSBM_Chunks, i, SearchLim);
+        if (UDFCBMGetBit(Vcb->FSBM_Chunks, i)) { // is the extent found free or used ?
             // wow! it is free!
             if (len >= Length) {
                 // minimize extent length
@@ -478,7 +475,7 @@ UDFCheckSpaceAllocation_(
                     AdPrint(("USED Mapping covers block(s) beyond media @%x\n",lba+j));
                     break;
                 }
-                if (!UDFGetUsedBit(Vcb->FSBM_Bitmap, lba+j)) {
+                if (UDFCBMGetBit(Vcb->FSBM_Chunks, lba+j)) {
                     BrutePoint();
                     AdPrint(("USED Mapping covers FREE block(s) @%x\n",lba+j));
                     break;
@@ -494,7 +491,7 @@ UDFCheckSpaceAllocation_(
                     AdPrint(("USED Mapping covers block(s) beyond media @%x\n",lba+j));
                     break;
                 }
-                if (!UDFGetFreeBit(Vcb->FSBM_Bitmap, lba+j)) {
+                if (!UDFCBMGetBit(Vcb->FSBM_Chunks, lba+j)) {
                     BrutePoint();
                     AdPrint(("FREE Mapping covers USED block(s) @%x\n",lba+j));
                     break;
@@ -515,15 +512,9 @@ UDFMarkBadSpaceAsUsed(
     IN ULONG len
     )
 {
-    uint32 j;
-#define BIT_C   (sizeof(Vcb->BSBM_Bitmap[0])*8)
-    len = (lba+len+BIT_C-1)/BIT_C;
     if (Vcb->BSBM_Bitmap) {
-        for(j=lba/BIT_C; j<len; j++) {
-            Vcb->FSBM_Bitmap[j] &= ~Vcb->BSBM_Bitmap[j];
-        }
+        UDFCBMApplyBSBM(Vcb->FSBM_Chunks, Vcb->BSBM_Bitmap, lba, len);
     }
-#undef BIT_C
 } // UDFMarkBadSpaceAsUsed()
 
 /*
@@ -599,8 +590,8 @@ UDFMarkSpaceAsXXXNoProtect_(
 
 #ifdef UDF_TRACK_ONDISK_ALLOCATION
         if (lba)
-            bit_before = UDFGetBit(Vcb->FSBM_Bitmap, lba-1);
-        bit_after = UDFGetBit(Vcb->FSBM_Bitmap, lba+len);
+            bit_before = UDFCBMGetBit(Vcb->FSBM_Chunks, lba-1);
+        bit_after = UDFCBMGetBit(Vcb->FSBM_Chunks, lba+len);
 #endif //UDF_TRACK_ONDISK_ALLOCATION
 
         // mark frag as XXX (see asUsed parameter)
@@ -609,10 +600,10 @@ UDFMarkSpaceAsXXXNoProtect_(
                 UDFSetUsedBit(Vcb->FSBM_Bitmap, lba+j);
             }*/
             ASSERT(len);
-            UDFSetUsedBits(Vcb->FSBM_Bitmap, lba, len);
+            UDFCBMClrBitRange(Vcb->FSBM_Chunks, lba, len);
 #ifdef UDF_TRACK_ONDISK_ALLOCATION
             for(j=0;j<len;j++) {
-                ASSERT(UDFGetUsedBit(Vcb->FSBM_Bitmap, lba+j));
+                ASSERT(!UDFCBMGetBit(Vcb->FSBM_Chunks, lba+j));
             }
 #endif //UDF_TRACK_ONDISK_ALLOCATION
 
@@ -631,10 +622,10 @@ UDFMarkSpaceAsXXXNoProtect_(
                 UDFSetFreeBit(Vcb->FSBM_Bitmap, lba+j);
             }*/
             ASSERT(len);
-            UDFSetFreeBits(Vcb->FSBM_Bitmap, lba, len);
+            UDFCBMSetBitRange(Vcb->FSBM_Chunks, lba, len);
 #ifdef UDF_TRACK_ONDISK_ALLOCATION
             for(j=0;j<len;j++) {
-                ASSERT(UDFGetFreeBit(Vcb->FSBM_Bitmap, lba+j));
+                ASSERT(UDFCBMGetBit(Vcb->FSBM_Chunks, lba+j));
             }
 #endif //UDF_TRACK_ONDISK_ALLOCATION
             if (asXXX & AS_BAD) {
@@ -661,8 +652,8 @@ UDFMarkSpaceAsXXXNoProtect_(
 
 #ifdef UDF_TRACK_ONDISK_ALLOCATION
         if (lba)
-            ASSERT(bit_before == UDFGetBit(Vcb->FSBM_Bitmap, lba-1));
-        ASSERT(bit_after == UDFGetBit(Vcb->FSBM_Bitmap, lba+len));
+            ASSERT(bit_before == UDFCBMGetBit(Vcb->FSBM_Chunks, lba-1));
+        ASSERT(bit_after == UDFCBMGetBit(Vcb->FSBM_Chunks, lba+len));
 #endif //UDF_TRACK_ONDISK_ALLOCATION
 
         i++;
@@ -833,16 +824,9 @@ UDFGetPartFreeSpace(
     IN uint32 partNum
     )
 {
-    uint32 lim/*, len=1*/;
-    uint32 s=0;
-    uint32 j;
-    PUCHAR cur = (PUCHAR)(Vcb->FSBM_Bitmap);
-
-    lim = (UDFPartEnd(Vcb,partNum)+7)/8;
-    for(j=(UDFPartStart(Vcb,partNum)+7)/8; j<lim/* && len*/; j++) {
-        s+=bit_count_tab[cur[j]];
-    }
-    return s;
+    return UDFCBMCountFreeBits(Vcb->FSBM_Chunks,
+                               UDFPartStart(Vcb, partNum),
+                               UDFPartEnd(Vcb, partNum));
 } // end UDFGetPartFreeSpace()
 
 int64

--- a/drivers/filesystems/udfs/udf_info/dirtree.cpp
+++ b/drivers/filesystems/udfs/udf_info/dirtree.cpp
@@ -652,7 +652,7 @@ UDFIndexDirectory(
 #ifdef UDF_CHECK_DISK_ALLOCATION
         if (!(FileId->fileCharacteristics & FILE_DELETED) &&
             (UDFPartLbaToPhys(Vcb, &(DirNdx->FileEntryLoc)) != LBA_OUT_OF_EXTENT) &&
-             UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), UDFPartLbaToPhys(Vcb, &(DirNdx->FileEntryLoc)) )) {
+             UDFCBMGetBit(Vcb->FSBM_Chunks, UDFPartLbaToPhys(Vcb, &(DirNdx->FileEntryLoc)) )) {
 
             AdPrint(("Ref to Discarded block %x\n",UDFPartLbaToPhys(Vcb, &(DirNdx->FileEntryLoc)) ));
             BrutePoint();

--- a/drivers/filesystems/udfs/udf_info/extent.cpp
+++ b/drivers/filesystems/udfs/udf_info/extent.cpp
@@ -2393,8 +2393,8 @@ UDFResizeExtent(
                     // how many sectors we should add
                     req_s = lim - s;
                     ASSERT(req_s);
-                    if ((lba < pe) && UDFGetFreeBit(Vcb->FSBM_Bitmap, lba)) {
-                        s += UDFGetBitmapLen((uint32*)(Vcb->FSBM_Bitmap), lba, min(pe, lba+req_s));
+                    if ((lba < pe) && UDFCBMGetBit(Vcb->FSBM_Chunks, lba)) {
+                        s += UDFCBMGetLen(Vcb->FSBM_Chunks, lba, min(pe, lba+req_s));
                     }
 /*                    for(s1=lba; (s<lim) && (s1<pe) && UDFGetFreeBit(Vcb->FSBM_Bitmap, s1); s1++) {
                         s++;
@@ -2465,8 +2465,8 @@ UDFResizeExtent(
 
                         UDFAcquireResourceExclusive(&(Vcb->BitMapResource1),TRUE);
                         //ASSERT(req_s);
-                        if ((lba < pe) && UDFGetFreeBit(Vcb->FSBM_Bitmap, lba)) {
-                            s += (d = UDFGetBitmapLen((uint32*)(Vcb->FSBM_Bitmap), lba, min(pe, lba+req_s)));
+                        if ((lba < pe) && UDFCBMGetBit(Vcb->FSBM_Chunks, lba)) {
+                            s += (d = UDFCBMGetLen(Vcb->FSBM_Chunks, lba, min(pe, lba+req_s)));
                         }
     /*                    for(s1=lba; (s<lim) && (s1<pe) && UDFGetFreeBit(Vcb->FSBM_Bitmap, s1); s1++) {
                             s++;

--- a/drivers/filesystems/udfs/udf_info/mount.cpp
+++ b/drivers/filesystems/udfs/udf_info/mount.cpp
@@ -196,10 +196,11 @@ UDFUpdateXSpaceBitmaps(
     uint32 plen, pstart, pend;
     int8* bad_bm;
     int8* old_bm;
+    int8* old_bm_decompressed = NULL;
     int8* new_bm;
     int8* fpart_bm;
     int8* upart_bm;
-    NTSTATUS status, status2;
+    NTSTATUS status, status2, rc;
     int8* USBM=NULL;
     int8* FSBM=NULL;
     uint32 USl, FSl;
@@ -220,8 +221,23 @@ UDFUpdateXSpaceBitmaps(
 
     pstart = UDFPartStart(Vcb, RefPartNum);
     new_bm = Vcb->FSBM_Bitmap;
-    old_bm = Vcb->FSBM_OldBitmap;
     bad_bm = Vcb->BSBM_Bitmap;
+
+    // Decompress the old bitmap snapshot for use in this function
+    if (Vcb->FSBM_OldBitmap) {
+        rc = UDFDecompressBitmap(Vcb->FSBM_OldBitmap,
+                                 Vcb->FSBM_OldBitmapCompressedSize,
+                                 Vcb->FSBM_ByteCount,
+                                 &old_bm_decompressed);
+        if (!NT_SUCCESS(rc)) {
+            UDFPrint(("UDFUpdateXSpaceBitmaps: failed to decompress old bitmap 0x%08X\n", rc));
+            old_bm = NULL;
+        } else {
+            old_bm = old_bm_decompressed;
+        }
+    } else {
+        old_bm = NULL;
+    }
 
     if ((status  == STATUS_INSUFFICIENT_RESOURCES) ||
        (status2 == STATUS_INSUFFICIENT_RESOURCES)) {
@@ -262,7 +278,7 @@ UDFUpdateXSpaceBitmaps(
         }
         j=0;
         for(i=pstart; i<pend; i+=d) {
-            if (UDFGetUsedBit(old_bm, i) && UDFGetFreeBit(new_bm, i)) {
+            if (old_bm && UDFGetUsedBit(old_bm, i) && UDFGetFreeBit(new_bm, i)) {
                 // sector was deallocated during last session
                 if (USBM) UDFSetFreeBit(upart_bm, j);
                 if (FSBM) UDFSetFreeBit(fpart_bm, j);
@@ -286,6 +302,10 @@ UDFUpdateXSpaceBitmaps(
         } else {
             status2 = status;
         }
+    }
+
+    if (old_bm_decompressed) {
+        DbgFreePool(old_bm_decompressed);
     }
 
     if (!NT_SUCCESS(status))
@@ -967,10 +987,29 @@ UDFUmount__(
 
     UDF_CHECK_BITMAP_RESOURCE(Vcb);
     // check if we should update BM
-    if (Vcb->FSBM_ByteCount == RtlCompareMemory(Vcb->FSBM_Bitmap, Vcb->FSBM_OldBitmap, Vcb->FSBM_ByteCount)) {
-        flags &= ~1;
-    } else {
-        flags |= 1;
+    {
+        int8* old_bm_decompressed = NULL;
+        NTSTATUS decompStatus;
+        if (Vcb->FSBM_OldBitmap) {
+            decompStatus = UDFDecompressBitmap(Vcb->FSBM_OldBitmap,
+                                               Vcb->FSBM_OldBitmapCompressedSize,
+                                               Vcb->FSBM_ByteCount,
+                                               &old_bm_decompressed);
+        } else {
+            decompStatus = STATUS_NOT_FOUND;
+        }
+        if (NT_SUCCESS(decompStatus)) {
+            if (Vcb->FSBM_ByteCount == RtlCompareMemory(Vcb->FSBM_Bitmap, old_bm_decompressed, Vcb->FSBM_ByteCount)) {
+                flags &= ~1;
+            } else {
+                flags |= 1;
+            }
+            DbgFreePool(old_bm_decompressed);
+        } else {
+            // If we can't decompress, conservatively assume the bitmap changed
+            UDFPrint(("UDFUmount__: failed to decompress old bitmap snapshot 0x%08X; assuming changed\n", decompStatus));
+            flags |= 1;
+        }
     }
 
 #ifdef UDF_DBG
@@ -988,8 +1027,24 @@ UDFUmount__(
         UDFUpdateLogicalVolInt(IrpContext, Vcb, TRUE);
     }
 
-    if (flags & 1)
-        RtlCopyMemory(Vcb->FSBM_OldBitmap, Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount);
+    if (flags & 1) {
+        // Re-compress the updated bitmap as the new old-bitmap snapshot.
+        // On failure the old snapshot is retained, causing the next flush
+        // to treat the bitmap as changed (safe but conservative).
+        PCHAR newCompressed = NULL;
+        ULONG newCompressedSize = 0;
+        NTSTATUS compStatus = UDFCompressBitmap(Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount,
+                                                &newCompressed, &newCompressedSize);
+        if (NT_SUCCESS(compStatus)) {
+            if (Vcb->FSBM_OldBitmap) {
+                DbgFreePool(Vcb->FSBM_OldBitmap);
+            }
+            Vcb->FSBM_OldBitmap = newCompressed;
+            Vcb->FSBM_OldBitmapCompressedSize = newCompressedSize;
+        } else {
+            UDFPrint(("UDFUmount__: failed to compress updated bitmap 0x%08X; retaining old snapshot\n", compStatus));
+        }
+    }
 
 //skip_update_bitmap:
 
@@ -2964,9 +3019,10 @@ UDFGetDiskInfoAndVerify(
 
         UDFLoadFileset(Vcb,FileSetDesc, &(Vcb->RootLbAddr), &(Vcb->SysStreamLbAddr));
 
-        Vcb->FSBM_OldBitmap = (int8*)DbgAllocatePool(NonPagedPool, Vcb->FSBM_ByteCount);
-        if (!(Vcb->FSBM_OldBitmap)) try_return(RC = STATUS_INSUFFICIENT_RESOURCES);
-        RtlCopyMemory(Vcb->FSBM_OldBitmap, Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount);
+        Vcb->FSBM_OldBitmapCompressedSize = 0;
+        RC = UDFCompressBitmap(Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount,
+                               &Vcb->FSBM_OldBitmap, &Vcb->FSBM_OldBitmapCompressedSize);
+        if (!NT_SUCCESS(RC)) try_return(RC);
 
 try_exit:   NOTHING;
     } _SEH2_FINALLY {

--- a/drivers/filesystems/udfs/udf_info/mount.cpp
+++ b/drivers/filesystems/udfs/udf_info/mount.cpp
@@ -229,7 +229,8 @@ UDFUpdateXSpaceBitmaps(
                                  Vcb->FSBM_ByteCount,
                                  &old_bm_decompressed);
         if (!NT_SUCCESS(rc)) {
-            UDFPrint(("UDFUpdateXSpaceBitmaps: failed to decompress old bitmap 0x%08X\n", rc));
+            UDFPrint(("UDFUpdateXSpaceBitmaps: failed to decompress old bitmap 0x%08X; "
+                      "proceeding without cross-session change detection\n", rc));
             old_bm = NULL;
         } else {
             old_bm = old_bm_decompressed;
@@ -1005,6 +1006,8 @@ UDFUmount__(
                 decompStatus = STATUS_NOT_FOUND;
             }
             if (NT_SUCCESS(decompStatus)) {
+                /* RtlCompareMemory returns the number of matching bytes;
+                 * equality means every byte matched → bitmap unchanged. */
                 if (Vcb->FSBM_ByteCount == RtlCompareMemory(current_flat, old_bm_decompressed, Vcb->FSBM_ByteCount)) {
                     flags &= ~1;
                 } else {

--- a/drivers/filesystems/udfs/udf_info/mount.cpp
+++ b/drivers/filesystems/udfs/udf_info/mount.cpp
@@ -197,7 +197,7 @@ UDFUpdateXSpaceBitmaps(
     int8* bad_bm;
     int8* old_bm;
     int8* old_bm_decompressed = NULL;
-    int8* new_bm;
+    int8* flat_new_bm = NULL;
     int8* fpart_bm;
     int8* upart_bm;
     NTSTATUS status, status2, rc;
@@ -220,7 +220,6 @@ UDFUpdateXSpaceBitmaps(
     }
 
     pstart = UDFPartStart(Vcb, RefPartNum);
-    new_bm = Vcb->FSBM_Bitmap;
     bad_bm = Vcb->BSBM_Bitmap;
 
     // Decompress the old bitmap snapshot for use in this function
@@ -241,10 +240,11 @@ UDFUpdateXSpaceBitmaps(
 
     if ((status  == STATUS_INSUFFICIENT_RESOURCES) ||
        (status2 == STATUS_INSUFFICIENT_RESOURCES)) {
-        // try to recover insufficient resources
-        if (USl && USBMExtInfo.Mapping) {
+        // try to recover insufficient resources: write flat FSBM directly
+        flat_new_bm = UDFCBMGetFlatBuf(Vcb->FSBM_Chunks);
+        if (USl && USBMExtInfo.Mapping && flat_new_bm) {
             USl -= sizeof(SPACE_BITMAP_DESC);
-            status  = UDFWriteExtent(IrpContext, Vcb, &USBMExtInfo, sizeof(SPACE_BITMAP_DESC), USl, FALSE, new_bm, &WrittenBytes);
+            status  = UDFWriteExtent(IrpContext, Vcb, &USBMExtInfo, sizeof(SPACE_BITMAP_DESC), USl, FALSE, flat_new_bm, &WrittenBytes);
 #ifdef UDF_DBG
         } else {
             UDFPrint(("Can't update USBM\n"));
@@ -252,9 +252,9 @@ UDFUpdateXSpaceBitmaps(
         }
         if (USBMExtInfo.Mapping) MyFreePool__(USBMExtInfo.Mapping);
 
-        if (FSl && FSBMExtInfo.Mapping) {
+        if (FSl && FSBMExtInfo.Mapping && flat_new_bm) {
             FSl -= sizeof(SPACE_BITMAP_DESC);
-            status2 = UDFWriteExtent(IrpContext, Vcb, &FSBMExtInfo, sizeof(SPACE_BITMAP_DESC), FSl, FALSE, new_bm, &WrittenBytes);
+            status2 = UDFWriteExtent(IrpContext, Vcb, &FSBMExtInfo, sizeof(SPACE_BITMAP_DESC), FSl, FALSE, flat_new_bm, &WrittenBytes);
         } else {
             status2 = status;
             UDFPrint(("Can't update FSBM\n"));
@@ -272,17 +272,17 @@ UDFUpdateXSpaceBitmaps(
             for(i=pstart; i<pend; i++) {
                 if (UDFGetBadBit(bad_bm, i)) {
                     // TODO: would be nice to add these blocks to unallocatable space
-                    UDFSetUsedBits(new_bm, i & ~(d-1), d);
+                    UDFCBMClrBitRange(Vcb->FSBM_Chunks, i & ~(d-1), d);
                 }
             }
         }
         j=0;
         for(i=pstart; i<pend; i+=d) {
-            if (old_bm && UDFGetUsedBit(old_bm, i) && UDFGetFreeBit(new_bm, i)) {
+            if (old_bm && UDFGetUsedBit(old_bm, i) && UDFCBMGetBit(Vcb->FSBM_Chunks, i)) {
                 // sector was deallocated during last session
                 if (USBM) UDFSetFreeBit(upart_bm, j);
                 if (FSBM) UDFSetFreeBit(fpart_bm, j);
-            } else if (UDFGetUsedBit(new_bm, i)) {
+            } else if (!UDFCBMGetBit(Vcb->FSBM_Chunks, i)) {
                 // allocated
                 if (USBM) UDFSetUsedBit(upart_bm, j);
                 if (FSBM) UDFSetUsedBit(fpart_bm, j);
@@ -302,6 +302,10 @@ UDFUpdateXSpaceBitmaps(
         } else {
             status2 = status;
         }
+    }
+
+    if (flat_new_bm) {
+        DbgFreePool(flat_new_bm);
     }
 
     if (old_bm_decompressed) {
@@ -988,26 +992,54 @@ UDFUmount__(
     UDF_CHECK_BITMAP_RESOURCE(Vcb);
     // check if we should update BM
     {
-        int8* old_bm_decompressed = NULL;
-        NTSTATUS decompStatus;
-        if (Vcb->FSBM_OldBitmap) {
-            decompStatus = UDFDecompressBitmap(Vcb->FSBM_OldBitmap,
-                                               Vcb->FSBM_OldBitmapCompressedSize,
-                                               Vcb->FSBM_ByteCount,
-                                               &old_bm_decompressed);
-        } else {
-            decompStatus = STATUS_NOT_FOUND;
-        }
-        if (NT_SUCCESS(decompStatus)) {
-            if (Vcb->FSBM_ByteCount == RtlCompareMemory(Vcb->FSBM_Bitmap, old_bm_decompressed, Vcb->FSBM_ByteCount)) {
-                flags &= ~1;
+        int8* current_flat = UDFCBMGetFlatBuf(Vcb->FSBM_Chunks);
+        if (current_flat) {
+            int8* old_bm_decompressed = NULL;
+            NTSTATUS decompStatus;
+            if (Vcb->FSBM_OldBitmap) {
+                decompStatus = UDFDecompressBitmap(Vcb->FSBM_OldBitmap,
+                                                   Vcb->FSBM_OldBitmapCompressedSize,
+                                                   Vcb->FSBM_ByteCount,
+                                                   &old_bm_decompressed);
             } else {
+                decompStatus = STATUS_NOT_FOUND;
+            }
+            if (NT_SUCCESS(decompStatus)) {
+                if (Vcb->FSBM_ByteCount == RtlCompareMemory(current_flat, old_bm_decompressed, Vcb->FSBM_ByteCount)) {
+                    flags &= ~1;
+                } else {
+                    flags |= 1;
+                }
+                DbgFreePool(old_bm_decompressed);
+            } else {
+                // If we can't decompress, conservatively assume the bitmap changed
+                UDFPrint(("UDFUmount__: failed to decompress old bitmap snapshot 0x%08X; assuming changed\n", decompStatus));
                 flags |= 1;
             }
-            DbgFreePool(old_bm_decompressed);
+
+            if (flags & 1) {
+                // Re-compress the updated bitmap as the new old-bitmap snapshot.
+                // On failure the old snapshot is retained (safe: next flush will
+                // treat bitmap as changed).
+                PCHAR newCompressed = NULL;
+                ULONG newCompressedSize = 0;
+                NTSTATUS compStatus = UDFCompressBitmap(current_flat, Vcb->FSBM_ByteCount,
+                                                        &newCompressed, &newCompressedSize);
+                if (NT_SUCCESS(compStatus)) {
+                    if (Vcb->FSBM_OldBitmap) {
+                        DbgFreePool(Vcb->FSBM_OldBitmap);
+                    }
+                    Vcb->FSBM_OldBitmap = newCompressed;
+                    Vcb->FSBM_OldBitmapCompressedSize = newCompressedSize;
+                } else {
+                    UDFPrint(("UDFUmount__: failed to compress updated bitmap 0x%08X; retaining old snapshot\n", compStatus));
+                }
+            }
+
+            DbgFreePool(current_flat);
         } else {
-            // If we can't decompress, conservatively assume the bitmap changed
-            UDFPrint(("UDFUmount__: failed to decompress old bitmap snapshot 0x%08X; assuming changed\n", decompStatus));
+            // Could not get flat view; assume bitmap changed
+            UDFPrint(("UDFUmount__: UDFCBMGetFlatBuf failed; assuming bitmap changed\n"));
             flags |= 1;
         }
     }
@@ -1025,25 +1057,6 @@ UDFUmount__(
     // Update Integrity Desc if any
     if (Vcb->LVid && Vcb->origIntegrityType == INTEGRITY_TYPE_CLOSE) {
         UDFUpdateLogicalVolInt(IrpContext, Vcb, TRUE);
-    }
-
-    if (flags & 1) {
-        // Re-compress the updated bitmap as the new old-bitmap snapshot.
-        // On failure the old snapshot is retained, causing the next flush
-        // to treat the bitmap as changed (safe but conservative).
-        PCHAR newCompressed = NULL;
-        ULONG newCompressedSize = 0;
-        NTSTATUS compStatus = UDFCompressBitmap(Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount,
-                                                &newCompressed, &newCompressedSize);
-        if (NT_SUCCESS(compStatus)) {
-            if (Vcb->FSBM_OldBitmap) {
-                DbgFreePool(Vcb->FSBM_OldBitmap);
-            }
-            Vcb->FSBM_OldBitmap = newCompressed;
-            Vcb->FSBM_OldBitmapCompressedSize = newCompressedSize;
-        } else {
-            UDFPrint(("UDFUmount__: failed to compress updated bitmap 0x%08X; retaining old snapshot\n", compStatus));
-        }
     }
 
 //skip_update_bitmap:
@@ -1729,7 +1742,7 @@ err_addxsbm_1:
             for(k=0;(k<l2) && (i<lim);k++) {
                 if (bit_set) {
                     // FREE block
-                    UDFSetFreeBit(Vcb->FSBM_Bitmap, i);
+                    UDFCBMSetBit(Vcb->FSBM_Chunks, i);
                     UDFSetFreeBitOwner(Vcb, i);
                 }
                 i++;
@@ -2017,24 +2030,25 @@ UDFBuildFreeSpaceBitmap(
     lb_addr locAddr;
     BOOLEAN UnallocSpaceExtent = FALSE;
 
-    if (!(Vcb->FSBM_Bitmap)) {
-        // init Bitmap buffer if necessary
-        Vcb->FSBM_Bitmap = (int8*)DbgAllocatePool(NonPagedPool, (i = (Vcb->LastPossibleLBA+1+7)>>3) );
-        if (!(Vcb->FSBM_Bitmap)) return STATUS_INSUFFICIENT_RESOURCES;
-
-        RtlZeroMemory(Vcb->FSBM_Bitmap, i);
+    if (!(Vcb->FSBM_Chunks)) {
+        // init chunked bitmap buffer if necessary
+        ULONG bitCount = Vcb->LastPossibleLBA + 1;
+        Vcb->FSBM_Chunks = UDFCBMCreate(bitCount);
+        if (!(Vcb->FSBM_Chunks)) return STATUS_INSUFFICIENT_RESOURCES;
 
 #ifdef UDF_TRACK_ONDISK_ALLOCATION_OWNERS
         Vcb->FSBM_Bitmap_owners = (uint32*)DbgAllocatePool(NonPagedPool, (Vcb->LastPossibleLBA+1)*sizeof(uint32));
         if (!(Vcb->FSBM_Bitmap_owners)) {
             MyFreePool__(Vcb->ZSBM_Bitmap);
             Vcb->ZSBM_Bitmap = NULL;
-            goto free_fsbm;
+            UDFCBMDestroy(Vcb->FSBM_Chunks);
+            Vcb->FSBM_Chunks = NULL;
+            return STATUS_INSUFFICIENT_RESOURCES;
         }
         RtlFillMemory(Vcb->FSBM_Bitmap_owners, (Vcb->LastPossibleLBA+1)*sizeof(uint32), 0xff);
 #endif //UDF_TRACK_ONDISK_ALLOCATION_OWNERS
-        Vcb->FSBM_ByteCount = i;
-        Vcb->FSBM_BitCount = Vcb->LastPossibleLBA+1;
+        Vcb->FSBM_ByteCount = (bitCount + 7) / 8;
+        Vcb->FSBM_BitCount = bitCount;
     }
     // read info for partition header (if any)
     if (phd) {
@@ -3019,10 +3033,17 @@ UDFGetDiskInfoAndVerify(
 
         UDFLoadFileset(Vcb,FileSetDesc, &(Vcb->RootLbAddr), &(Vcb->SysStreamLbAddr));
 
-        Vcb->FSBM_OldBitmapCompressedSize = 0;
-        RC = UDFCompressBitmap(Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount,
-                               &Vcb->FSBM_OldBitmap, &Vcb->FSBM_OldBitmapCompressedSize);
-        if (!NT_SUCCESS(RC)) try_return(RC);
+        {
+            // Take a compressed snapshot of the initial bitmap for change detection
+            PCHAR current_flat = UDFCBMGetFlatBuf(Vcb->FSBM_Chunks);
+            if (!current_flat) try_return(RC = STATUS_INSUFFICIENT_RESOURCES);
+
+            Vcb->FSBM_OldBitmapCompressedSize = 0;
+            RC = UDFCompressBitmap(current_flat, Vcb->FSBM_ByteCount,
+                                   &Vcb->FSBM_OldBitmap, &Vcb->FSBM_OldBitmapCompressedSize);
+            DbgFreePool(current_flat);
+            if (!NT_SUCCESS(RC)) try_return(RC);
+        }
 
 try_exit:   NOTHING;
     } _SEH2_FINALLY {

--- a/drivers/filesystems/udfs/udf_info/udf_info.cpp
+++ b/drivers/filesystems/udfs/udf_info/udf_info.cpp
@@ -5287,3 +5287,135 @@ UDFPretendFileDeleted__(
     }
     return STATUS_SUCCESS;
 } // end UDFPretendFileDeleted__()
+
+/*
+    Compress a bitmap buffer using RtlCompressBuffer (LZNT1).
+    On success, *CompressedBuffer is allocated from NonPagedPool and
+    *CompressedSize is set to the number of bytes written.
+    The caller is responsible for freeing the buffer with DbgFreePool.
+    Returns STATUS_SUCCESS on success, or an error status.
+    Falls back to returning the uncompressed data if the result is larger.
+ */
+NTSTATUS
+UDFCompressBitmap(
+    IN PCHAR  UncompressedData,
+    IN ULONG  UncompressedSize,
+    OUT PCHAR *CompressedBuffer,
+    OUT ULONG *CompressedSize
+    )
+{
+    NTSTATUS status;
+    ULONG workSpaceSize, fragWorkSpaceSize;
+    PVOID workSpace = NULL;
+    PCHAR compBuf = NULL;
+    PCHAR tightBuf = NULL;
+    ULONG finalSize = 0;
+
+    *CompressedBuffer = NULL;
+    *CompressedSize = 0;
+
+    status = RtlGetCompressionWorkSpaceSize(
+        COMPRESSION_FORMAT_LZNT1 | COMPRESSION_ENGINE_STANDARD,
+        &workSpaceSize,
+        &fragWorkSpaceSize);
+    if (!NT_SUCCESS(status)) {
+        UDFPrint(("UDFCompressBitmap: RtlGetCompressionWorkSpaceSize failed 0x%08X\n", status));
+        return status;
+    }
+
+    workSpace = DbgAllocatePool(NonPagedPool, workSpaceSize);
+    if (!workSpace) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    // Allocate a worst-case-sized buffer for the compressed output
+    compBuf = (PCHAR)DbgAllocatePool(NonPagedPool, UncompressedSize);
+    if (!compBuf) {
+        DbgFreePool(workSpace);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    status = RtlCompressBuffer(
+        COMPRESSION_FORMAT_LZNT1 | COMPRESSION_ENGINE_STANDARD,
+        (PUCHAR)UncompressedData,
+        UncompressedSize,
+        (PUCHAR)compBuf,
+        UncompressedSize,
+        4096,
+        &finalSize,
+        workSpace);
+
+    DbgFreePool(workSpace);
+
+    if (!NT_SUCCESS(status) || finalSize >= UncompressedSize) {
+        // Compression didn't help or failed; store uncompressed copy in the
+        // existing buffer to avoid a free/allocate cycle
+        RtlCopyMemory(compBuf, UncompressedData, UncompressedSize);
+        *CompressedBuffer = compBuf;
+        *CompressedSize = 0; // 0 signals "stored uncompressed"
+        return STATUS_SUCCESS;
+    }
+
+    // Compression succeeded: allocate a tighter buffer to avoid wasting memory
+    tightBuf = (PCHAR)DbgAllocatePool(NonPagedPool, finalSize);
+    if (tightBuf) {
+        RtlCopyMemory(tightBuf, compBuf, finalSize);
+        DbgFreePool(compBuf);
+        *CompressedBuffer = tightBuf;
+    } else {
+        // Fall back to the over-sized buffer
+        *CompressedBuffer = compBuf;
+    }
+    *CompressedSize = finalSize;
+    return STATUS_SUCCESS;
+} // end UDFCompressBitmap()
+
+/*
+    Decompress a bitmap buffer previously compressed with UDFCompressBitmap.
+    If CompressedSize is 0, the buffer is treated as uncompressed and simply
+    copied.  On success, *DecompressedBuffer is allocated from NonPagedPool.
+    The caller is responsible for freeing it with DbgFreePool.
+ */
+NTSTATUS
+UDFDecompressBitmap(
+    IN PCHAR  CompressedData,
+    IN ULONG  CompressedSize,
+    IN ULONG  UncompressedSize,
+    OUT PCHAR *DecompressedBuffer
+    )
+{
+    NTSTATUS status;
+    PCHAR buf;
+    ULONG finalSize = 0;
+
+    *DecompressedBuffer = NULL;
+
+    buf = (PCHAR)DbgAllocatePool(NonPagedPool, UncompressedSize);
+    if (!buf) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    if (CompressedSize == 0) {
+        // Data was stored uncompressed
+        RtlCopyMemory(buf, CompressedData, UncompressedSize);
+        *DecompressedBuffer = buf;
+        return STATUS_SUCCESS;
+    }
+
+    status = RtlDecompressBuffer(
+        COMPRESSION_FORMAT_LZNT1,
+        (PUCHAR)buf,
+        UncompressedSize,
+        (PUCHAR)CompressedData,
+        CompressedSize,
+        &finalSize);
+
+    if (!NT_SUCCESS(status)) {
+        UDFPrint(("UDFDecompressBitmap: RtlDecompressBuffer failed 0x%08X\n", status));
+        DbgFreePool(buf);
+        return status;
+    }
+
+    *DecompressedBuffer = buf;
+    return STATUS_SUCCESS;
+} // end UDFDecompressBitmap()

--- a/drivers/filesystems/udfs/udf_info/udf_info.cpp
+++ b/drivers/filesystems/udfs/udf_info/udf_info.cpp
@@ -2835,7 +2835,7 @@ CrF__2:
 
 #ifdef UDF_CHECK_DISK_ALLOCATION
         if (  /*FileInfo->Fcb &&*/
-             UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
+             UDFCBMGetBit(Vcb->FSBM_Chunks, FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
 
             if (!FileInfo->FileIdent ||
                !(FileInfo->FileIdent->fileCharacteristics & FILE_DELETED)) {
@@ -3044,7 +3044,7 @@ UDFCloseFile__(
     }
 #ifdef UDF_CHECK_DISK_ALLOCATION
     if (  FileInfo->Fcb &&
-         UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
+         UDFCBMGetBit(Vcb->FSBM_Chunks, FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
 
         //ASSERT(FileInfo->Dloc->FELoc.Mapping[0].extLocation);
         if (UDFIsAStreamDir(FileInfo)) {
@@ -3071,7 +3071,7 @@ UDFCloseFile__(
         }
     } else {
         if (!FileInfo->Dloc->FELoc.Mapping[0].extLocation ||
-            UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
+            UDFCBMGetBit(Vcb->FSBM_Chunks, FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
             UDFCheckSpaceAllocation(Vcb, 0, FileInfo->Dloc->DataLoc.Mapping, AS_FREE); // check if free
         } else {
             UDFCheckSpaceAllocation(Vcb, 0, FileInfo->Dloc->DataLoc.Mapping, AS_USED); // check if used
@@ -3138,7 +3138,7 @@ UDFCloseFile__(
 //    ASSERT(FileInfo->Dloc->FELoc.Mapping[0].extLocation);
     if ((FileInfo->Dloc->FileEntry->descVersion != 2) &&
        (FileInfo->Dloc->FileEntry->descVersion != 3)) {
-        ASSERT(UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), FileInfo->Dloc->FELoc.Mapping[0].extLocation));
+        ASSERT(UDFCBMGetBit(Vcb->FSBM_Chunks, FileInfo->Dloc->FELoc.Mapping[0].extLocation));
     }
 #endif // UDF_DBG
     return STATUS_SUCCESS;
@@ -3737,7 +3737,7 @@ err_vat_15:
         // sync VAT and FSBM
         for(i=0; i<len; i++) {
             if (Vcb->Vat[i] == UDF_VAT_FREE_ENTRY) {
-                UDFSetFreeBit(Vcb->FSBM_Bitmap, root+i);
+                UDFCBMSetBit(Vcb->FSBM_Chunks, root+i);
             }
         }
         len = Vcb->LastPossibleLBA;
@@ -3746,12 +3746,12 @@ err_vat_15:
             for (j = 0; (j < PACKETSIZE_UDF) && (i < len); j++, i++)
             {
                 UDFPrint(("udf_info:FSBM_Bitmap Set Free: %x\n", root + i));
-                UDFSetFreeBit(Vcb->FSBM_Bitmap, i);
+                UDFCBMSetBit(Vcb->FSBM_Chunks, i);
             }
             for (j = 0; (j < 7) && (i < len); j++, i++)
             {
                 UDFPrint(("udf_info:FSBM_Bitmap Set Used: %x\n", root + i));
-                UDFSetUsedBit(Vcb->FSBM_Bitmap, i);
+                UDFCBMClrBit(Vcb->FSBM_Chunks, i);
             }
         }
         DbgFreePool(VatOldData);
@@ -3937,7 +3937,7 @@ retry_flush_FE:
     }
 /*    if (FileInfo->Fcb &&
        ((FileInfo->Dloc->FELoc.Mapping[0].extLocation > Vcb->LastLBA) ||
-        UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), FileInfo->Dloc->FELoc.Mapping[0].extLocation)) ) {
+        UDFCBMGetBit(Vcb->FSBM_Chunks, FileInfo->Dloc->FELoc.Mapping[0].extLocation)) ) {
         BrutePoint();
     }*/
 /*    if (FileInfo->Dloc->FELoc.Mapping[0].extLocation) {
@@ -4146,7 +4146,7 @@ UDFFlushFile__(
     }
 #ifdef UDF_CHECK_DISK_ALLOCATION
     if ( FileInfo->Fcb &&
-        UDFGetFreeBit(((uint32*)(Vcb->FSBM_Bitmap)), FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
+        UDFCBMGetBit(Vcb->FSBM_Chunks, FileInfo->Dloc->FELoc.Mapping[0].extLocation)) {
 
         if (UDFIsAStreamDir(FileInfo)) {
             if (!UDFIsSDirDeleted(FileInfo)) {
@@ -4867,7 +4867,7 @@ UDFRecordVAT(
     len = min(UDFPartLen(Vcb, PartNum), Vcb->FSBM_BitCount - root);
     len = min(Vcb->VatCount, len);
     for(i=0; i<len; i++) {
-        if (UDFGetFreeBit(Vcb->FSBM_Bitmap, root+i))
+        if (UDFCBMGetBit(Vcb->FSBM_Chunks, root+i))
             Vat[i] = UDF_VAT_FREE_ENTRY;
     }
     // Ok, now we shall construct new VAT image...
@@ -5419,3 +5419,553 @@ UDFDecompressBitmap(
     *DecompressedBuffer = buf;
     return STATUS_SUCCESS;
 } // end UDFDecompressBitmap()
+
+/*
+ * Chunked Compressed Free-Space Bitmap (CBM) implementation.
+ *
+ * The Free-Space Bitmap maps every LBA on the volume to one bit:
+ *   1 = free, 0 = used.
+ * For a 256 GiB volume with 2 KiB sectors the flat bitmap is 16 MiB.
+ * The chunked scheme stores the bitmap as an array of LZNT1-compressed
+ * 64 KiB chunks so that only a few MiB of NonPagedPool are needed at rest.
+ * A single 64 KiB "hot" buffer is kept decompressed for bit operations.
+ * Accessing a different chunk flushes (re-compresses) the current hot
+ * chunk and decompresses the requested one.
+ */
+
+/*
+ * Allocate and initialise a new chunked bitmap for 'BitCount' LBAs.
+ * All chunks start as NULL (all-zero = all sectors marked USED).
+ * Returns NULL on allocation failure.
+ */
+PUDF_CHUNKED_FSBM
+UDFCBMCreate(
+    IN ULONG BitCount
+    )
+{
+    PUDF_CHUNKED_FSBM cb;
+    ULONG chunkCount;
+
+    if (!BitCount)
+        return NULL;
+
+    chunkCount = (BitCount + UDF_FSBM_CHUNK_BITS - 1) / UDF_FSBM_CHUNK_BITS;
+
+    cb = (PUDF_CHUNKED_FSBM)DbgAllocatePool(NonPagedPool, sizeof(UDF_CHUNKED_FSBM));
+    if (!cb)
+        return NULL;
+
+    RtlZeroMemory(cb, sizeof(UDF_CHUNKED_FSBM));
+
+    cb->HotData = (PCHAR)DbgAllocatePool(NonPagedPool, UDF_FSBM_CHUNK_BYTES);
+    if (!cb->HotData) {
+        DbgFreePool(cb);
+        return NULL;
+    }
+    RtlZeroMemory(cb->HotData, UDF_FSBM_CHUNK_BYTES);
+
+    cb->Chunks = (PUDF_FSBM_CHUNK)DbgAllocatePool(NonPagedPool,
+                     chunkCount * sizeof(UDF_FSBM_CHUNK));
+    if (!cb->Chunks) {
+        DbgFreePool(cb->HotData);
+        DbgFreePool(cb);
+        return NULL;
+    }
+    RtlZeroMemory(cb->Chunks, chunkCount * sizeof(UDF_FSBM_CHUNK));
+
+    cb->ChunkCount = chunkCount;
+    cb->BitCount   = BitCount;
+    cb->ByteCount  = (BitCount + 7) / 8;
+    cb->HotIdx     = UDF_FSBM_NO_HOT_CHUNK;
+    cb->HotDirty   = FALSE;
+
+    return cb;
+} // end UDFCBMCreate()
+
+/*
+ * Free all resources owned by a chunked bitmap.
+ */
+VOID
+UDFCBMDestroy(
+    IN PUDF_CHUNKED_FSBM cb
+    )
+{
+    ULONG i;
+
+    if (!cb)
+        return;
+
+    if (cb->Chunks) {
+        for (i = 0; i < cb->ChunkCount; i++) {
+            if (cb->Chunks[i].CompressedData) {
+                DbgFreePool(cb->Chunks[i].CompressedData);
+                cb->Chunks[i].CompressedData = NULL;
+            }
+        }
+        DbgFreePool(cb->Chunks);
+        cb->Chunks = NULL;
+    }
+
+    if (cb->HotData) {
+        DbgFreePool(cb->HotData);
+        cb->HotData = NULL;
+    }
+
+    DbgFreePool(cb);
+} // end UDFCBMDestroy()
+
+/*
+ * If the hot chunk is dirty, recompress it and store it back.
+ */
+NTSTATUS
+UDFCBMFlushHot(
+    IN PUDF_CHUNKED_FSBM cb
+    )
+{
+    PCHAR newData = NULL;
+    ULONG newSize = 0;
+    NTSTATUS st;
+
+    if (!cb || !cb->HotDirty || cb->HotIdx == UDF_FSBM_NO_HOT_CHUNK)
+        return STATUS_SUCCESS;
+
+    st = UDFCompressBitmap(cb->HotData, UDF_FSBM_CHUNK_BYTES, &newData, &newSize);
+    if (!NT_SUCCESS(st))
+        return st;
+
+    if (cb->Chunks[cb->HotIdx].CompressedData)
+        DbgFreePool(cb->Chunks[cb->HotIdx].CompressedData);
+    cb->Chunks[cb->HotIdx].CompressedData = newData;
+    cb->Chunks[cb->HotIdx].CompressedSize = newSize;
+    cb->HotDirty = FALSE;
+    return STATUS_SUCCESS;
+} // end UDFCBMFlushHot()
+
+/*
+ * Ensure chunk 'chunkIdx' is decompressed in the hot buffer.
+ * Flushes the current hot chunk first if it is dirty.
+ */
+NTSTATUS
+UDFCBMPinChunk(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG chunkIdx
+    )
+{
+    NTSTATUS st;
+    ULONG    finalSize;
+    ULONG    chunkBytes;
+
+    if (!cb || chunkIdx >= cb->ChunkCount)
+        return STATUS_INVALID_PARAMETER;
+
+    if (cb->HotIdx == chunkIdx)
+        return STATUS_SUCCESS;
+
+    /* Flush the current hot chunk (if any and if dirty) */
+    st = UDFCBMFlushHot(cb);
+    if (!NT_SUCCESS(st))
+        return st;
+
+    /* How many bytes are in this chunk (last chunk may be partial) */
+    chunkBytes = min(UDF_FSBM_CHUNK_BYTES,
+                     cb->ByteCount - chunkIdx * UDF_FSBM_CHUNK_BYTES);
+
+    /* Load the chunk into HotData */
+    if (cb->Chunks[chunkIdx].CompressedData == NULL) {
+        /* All-zero chunk: never been written, every sector is USED */
+        RtlZeroMemory(cb->HotData, UDF_FSBM_CHUNK_BYTES);
+    } else if (cb->Chunks[chunkIdx].CompressedSize == 0) {
+        /* Stored verbatim (uncompressed) */
+        RtlCopyMemory(cb->HotData, cb->Chunks[chunkIdx].CompressedData, chunkBytes);
+        if (chunkBytes < UDF_FSBM_CHUNK_BYTES)
+            RtlZeroMemory(cb->HotData + chunkBytes,
+                          UDF_FSBM_CHUNK_BYTES - chunkBytes);
+    } else {
+        /* LZNT1 compressed */
+        finalSize = 0;
+        st = RtlDecompressBuffer(
+                COMPRESSION_FORMAT_LZNT1,
+                (PUCHAR)cb->HotData, UDF_FSBM_CHUNK_BYTES,
+                (PUCHAR)cb->Chunks[chunkIdx].CompressedData,
+                cb->Chunks[chunkIdx].CompressedSize,
+                &finalSize);
+        if (!NT_SUCCESS(st)) {
+            UDFPrint(("UDFCBMPinChunk: decompress failed 0x%08X, zeroing chunk %u\n",
+                      st, chunkIdx));
+            RtlZeroMemory(cb->HotData, UDF_FSBM_CHUNK_BYTES);
+        } else if (finalSize < UDF_FSBM_CHUNK_BYTES) {
+            RtlZeroMemory(cb->HotData + finalSize,
+                          UDF_FSBM_CHUNK_BYTES - finalSize);
+        }
+    }
+
+    cb->HotIdx   = chunkIdx;
+    cb->HotDirty = FALSE;
+    return STATUS_SUCCESS;
+} // end UDFCBMPinChunk()
+
+/*
+ * Read a single bit.  TRUE = 1 = free, FALSE = 0 = used.
+ */
+BOOLEAN
+UDFCBMGetBit(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG bit
+    )
+{
+    ULONG chunkIdx   = bit / UDF_FSBM_CHUNK_BITS;
+    ULONG bitInChunk = bit % UDF_FSBM_CHUNK_BITS;
+
+    if (!cb || chunkIdx >= cb->ChunkCount)
+        return FALSE;
+
+    if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+        return FALSE;
+
+    return UDFGetBit((uint32*)cb->HotData, bitInChunk);
+} // end UDFCBMGetBit()
+
+/*
+ * Set a single bit to 1 (mark LBA as free).
+ */
+VOID
+UDFCBMSetBit(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG bit
+    )
+{
+    ULONG chunkIdx   = bit / UDF_FSBM_CHUNK_BITS;
+    ULONG bitInChunk = bit % UDF_FSBM_CHUNK_BITS;
+
+    if (!cb || chunkIdx >= cb->ChunkCount)
+        return;
+
+    if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+        return;
+
+    UDFSetBit((uint32*)cb->HotData, bitInChunk);
+    cb->HotDirty = TRUE;
+} // end UDFCBMSetBit()
+
+/*
+ * Clear a single bit to 0 (mark LBA as used).
+ */
+VOID
+UDFCBMClrBit(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG bit
+    )
+{
+    ULONG chunkIdx   = bit / UDF_FSBM_CHUNK_BITS;
+    ULONG bitInChunk = bit % UDF_FSBM_CHUNK_BITS;
+
+    if (!cb || chunkIdx >= cb->ChunkCount)
+        return;
+
+    if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+        return;
+
+    UDFClrBit((uint32*)cb->HotData, bitInChunk);
+    cb->HotDirty = TRUE;
+} // end UDFCBMClrBit()
+
+/*
+ * Set 'count' consecutive bits to 1 (free), chunk-by-chunk.
+ */
+VOID
+UDFCBMSetBitRange(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG startBit,
+    IN ULONG count
+    )
+{
+    ULONG end = startBit + count;
+    ULONG bit = startBit;
+
+    if (!cb) return;
+
+    while (bit < end) {
+        ULONG chunkIdx       = bit / UDF_FSBM_CHUNK_BITS;
+        ULONG bitInChunk     = bit % UDF_FSBM_CHUNK_BITS;
+        ULONG nextChunkStart = (chunkIdx + 1) * UDF_FSBM_CHUNK_BITS;
+        ULONG bitsHere       = min(end, nextChunkStart) - bit;
+
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+            break;
+
+        UDFSetBits((uint32*)cb->HotData, bitInChunk, bitsHere);
+        cb->HotDirty = TRUE;
+        bit += bitsHere;
+    }
+} // end UDFCBMSetBitRange()
+
+/*
+ * Clear 'count' consecutive bits to 0 (used), chunk-by-chunk.
+ */
+VOID
+UDFCBMClrBitRange(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG startBit,
+    IN ULONG count
+    )
+{
+    ULONG end = startBit + count;
+    ULONG bit = startBit;
+
+    if (!cb) return;
+
+    while (bit < end) {
+        ULONG chunkIdx       = bit / UDF_FSBM_CHUNK_BITS;
+        ULONG bitInChunk     = bit % UDF_FSBM_CHUNK_BITS;
+        ULONG nextChunkStart = (chunkIdx + 1) * UDF_FSBM_CHUNK_BITS;
+        ULONG bitsHere       = min(end, nextChunkStart) - bit;
+
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+            break;
+
+        UDFClrBits((uint32*)cb->HotData, bitInChunk, bitsHere);
+        cb->HotDirty = TRUE;
+        bit += bitsHere;
+    }
+} // end UDFCBMClrBitRange()
+
+/*
+ * Return the length of the run of same-value bits starting at 'start',
+ * up to (but not including) 'limit'.  Spans chunk boundaries correctly.
+ */
+SIZE_T
+UDFCBMGetLen(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG start,
+    IN ULONG limit
+    )
+{
+    BOOLEAN startBit;
+    SIZE_T  len = 0;
+    ULONG   bit;
+
+    if (!cb || start >= limit)
+        return 0;
+
+    limit = min(limit, cb->BitCount);
+    bit   = start;
+
+    /* Determine value of the starting bit */
+    {
+        ULONG chunkIdx   = bit / UDF_FSBM_CHUNK_BITS;
+        ULONG bitInChunk = bit % UDF_FSBM_CHUNK_BITS;
+
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+            return 0;
+
+        startBit = UDFGetBit((uint32*)cb->HotData, bitInChunk);
+    }
+
+    /* Extend the run chunk by chunk */
+    while (bit < limit) {
+        ULONG  chunkIdx       = bit / UDF_FSBM_CHUNK_BITS;
+        ULONG  bitInChunk     = bit % UDF_FSBM_CHUNK_BITS;
+        ULONG  nextChunkStart = (chunkIdx + 1) * UDF_FSBM_CHUNK_BITS;
+        ULONG  localLimit     = min(limit, nextChunkStart) - chunkIdx * UDF_FSBM_CHUNK_BITS;
+        SIZE_T addLen;
+
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+            break;
+
+        /* If we've crossed into a new chunk, verify the run continues */
+        if (len > 0 && UDFGetBit((uint32*)cb->HotData, bitInChunk) != startBit)
+            break;
+
+        addLen = UDFGetBitmapLen((uint32*)cb->HotData, bitInChunk, localLimit);
+        len += addLen;
+        bit += (ULONG)addLen;
+
+        /* If run ended before the chunk boundary (or hit limit), stop */
+        if (bit < nextChunkStart || bit >= limit)
+            break;
+    }
+
+    return len;
+} // end UDFCBMGetLen()
+
+/*
+ * Count bits set to 1 (free) in [startBit, endBit).
+ * Uses byte-level nibble counting within each chunk.
+ */
+ULONG
+UDFCBMCountFreeBits(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN ULONG startBit,
+    IN ULONG endBit
+    )
+{
+    /* Nibble lookup table: popcount of 4-bit values */
+    static const UCHAR bc[16] = {0,1,1,2,1,2,2,3,1,2,2,3,2,3,3,4};
+    ULONG count     = 0;
+    ULONG startByte, endByte;
+
+    if (!cb || startBit >= endBit)
+        return 0;
+
+    startByte = startBit / 8;
+    endByte   = min((endBit + 7) / 8, cb->ByteCount);
+
+    while (startByte < endByte) {
+        ULONG chunkIdx    = startByte / UDF_FSBM_CHUNK_BYTES;
+        ULONG byteInChunk = startByte % UDF_FSBM_CHUNK_BYTES;
+        ULONG endThisIter = min(endByte, (chunkIdx + 1) * UDF_FSBM_CHUNK_BYTES);
+        ULONG jEnd        = byteInChunk + (endThisIter - startByte);
+        ULONG j;
+
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+            break;
+
+        for (j = byteInChunk; j < jEnd; j++) {
+            UCHAR b = (UCHAR)cb->HotData[j];
+            count += bc[b & 0xF] + bc[b >> 4];
+        }
+
+        startByte = endThisIter;
+    }
+
+    return count;
+} // end UDFCBMCountFreeBits()
+
+/*
+ * Produce a flat (uncompressed) copy of the entire chunked bitmap.
+ * The caller must free the returned buffer with DbgFreePool().
+ * Returns NULL on allocation failure.
+ * The hot-chunk slot is invalidated so the scratch buffer is free for reuse.
+ */
+PCHAR
+UDFCBMGetFlatBuf(
+    IN PUDF_CHUNKED_FSBM cb
+    )
+{
+    PCHAR flat;
+    ULONG ci, start, bytes, finalSize;
+
+    if (!cb)
+        return NULL;
+
+    /* Flush any pending dirty chunk so compressed data is current */
+    if (!NT_SUCCESS(UDFCBMFlushHot(cb)))
+        return NULL;
+
+    flat = (PCHAR)DbgAllocatePool(NonPagedPool, cb->ByteCount);
+    if (!flat)
+        return NULL;
+
+    for (ci = 0; ci < cb->ChunkCount; ci++) {
+        start = ci * UDF_FSBM_CHUNK_BYTES;
+        bytes = min(UDF_FSBM_CHUNK_BYTES, cb->ByteCount - start);
+
+        if (cb->Chunks[ci].CompressedData == NULL) {
+            RtlZeroMemory(flat + start, bytes);
+        } else if (cb->Chunks[ci].CompressedSize == 0) {
+            RtlCopyMemory(flat + start, cb->Chunks[ci].CompressedData, bytes);
+        } else {
+            /* Decompress into the hot buffer, then copy the valid bytes */
+            finalSize = 0;
+            RtlDecompressBuffer(
+                COMPRESSION_FORMAT_LZNT1,
+                (PUCHAR)cb->HotData, UDF_FSBM_CHUNK_BYTES,
+                (PUCHAR)cb->Chunks[ci].CompressedData,
+                cb->Chunks[ci].CompressedSize,
+                &finalSize);
+            RtlCopyMemory(flat + start, cb->HotData, bytes);
+        }
+    }
+
+    /* Invalidate the hot slot since we used HotData as a scratch buffer */
+    cb->HotIdx   = UDF_FSBM_NO_HOT_CHUNK;
+    cb->HotDirty = FALSE;
+
+    return flat;
+} // end UDFCBMGetFlatBuf()
+
+/*
+ * Build a chunked bitmap by compressing an existing flat buffer.
+ * 'byteCount' is the number of valid bytes in 'flat'.
+ * Returns NULL on allocation failure.
+ */
+PUDF_CHUNKED_FSBM
+UDFCBMFromFlat(
+    IN PCHAR flat,
+    IN ULONG byteCount
+    )
+{
+    PUDF_CHUNKED_FSBM cb;
+    ULONG ci, start, bytes;
+
+    if (!flat || !byteCount)
+        return NULL;
+
+    cb = UDFCBMCreate(byteCount * 8);
+    if (!cb)
+        return NULL;
+
+    for (ci = 0; ci < cb->ChunkCount; ci++) {
+        start = ci * UDF_FSBM_CHUNK_BYTES;
+        bytes = min(UDF_FSBM_CHUNK_BYTES, byteCount - start);
+
+        /* Copy this slice into the hot buffer (zero-pad if partial) */
+        RtlCopyMemory(cb->HotData, flat + start, bytes);
+        if (bytes < UDF_FSBM_CHUNK_BYTES)
+            RtlZeroMemory(cb->HotData + bytes, UDF_FSBM_CHUNK_BYTES - bytes);
+
+        /* Compress and store */
+        UDFCompressBitmap(cb->HotData, UDF_FSBM_CHUNK_BYTES,
+                          &cb->Chunks[ci].CompressedData,
+                          &cb->Chunks[ci].CompressedSize);
+    }
+
+    /* Last chunk's data is still in HotData but we won't track it as hot
+     * since we don't hold the HotDirty invariant here. */
+    cb->HotIdx   = UDF_FSBM_NO_HOT_CHUNK;
+    cb->HotDirty = FALSE;
+
+    return cb;
+} // end UDFCBMFromFlat()
+
+/*
+ * Apply the bad-sector bitmap (BSBM) to the free-space bitmap (CBM).
+ * For every byte in [lba/8, (lba+len+7)/8), clear FSBM bits that are
+ * set in BSBM (marking those sectors as USED).  Operates chunk-by-chunk
+ * so each chunk switch is amortised across many bytes.
+ */
+VOID
+UDFCBMApplyBSBM(
+    IN PUDF_CHUNKED_FSBM cb,
+    IN PCHAR bsbm,
+    IN ULONG lba,
+    IN ULONG len
+    )
+{
+    ULONG startByte, endByte, j;
+
+    if (!cb || !bsbm || !len)
+        return;
+
+    startByte = lba / 8;
+    endByte   = min((lba + len + 7) / 8, cb->ByteCount);
+    j         = startByte;
+
+    while (j < endByte) {
+        ULONG chunkIdx    = j / UDF_FSBM_CHUNK_BYTES;
+        ULONG byteInChunk = j % UDF_FSBM_CHUNK_BYTES;
+        ULONG endThisIter = min(endByte, (chunkIdx + 1) * UDF_FSBM_CHUNK_BYTES);
+        ULONG k;
+
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+            break;
+
+        for (k = byteInChunk; j < endThisIter; k++, j++) {
+            UCHAR mask = (UCHAR)bsbm[j];
+            if (mask) {
+                ((PUCHAR)cb->HotData)[k] &= ~mask;
+                cb->HotDirty = TRUE;
+            }
+        }
+    }
+} // end UDFCBMApplyBSBM()

--- a/drivers/filesystems/udfs/udf_info/udf_info.cpp
+++ b/drivers/filesystems/udfs/udf_info/udf_info.cpp
@@ -5530,13 +5530,43 @@ UDFCBMFlushHot(
         return STATUS_SUCCESS;
 
     st = UDFCompressBitmap(cb->HotData, UDF_FSBM_CHUNK_BYTES, &newData, &newSize);
-    if (!NT_SUCCESS(st))
+    if (!NT_SUCCESS(st)) {
+        UDFPrint(("UDFCBMFlushHot: compress failed for chunk %u: 0x%08X\n",
+                  cb->HotIdx, st));
         return st;
+    }
 
     if (cb->Chunks[cb->HotIdx].CompressedData)
         DbgFreePool(cb->Chunks[cb->HotIdx].CompressedData);
     cb->Chunks[cb->HotIdx].CompressedData = newData;
     cb->Chunks[cb->HotIdx].CompressedSize = newSize;
+
+    /* Compute uniform-chunk fast-path hint while HotData is still live.
+     * 0x00 = all-zeros (all USED), 0x01 = all-ones (all FREE), 0x02 = mixed.
+     * Only scan the full chunk when the first word looks uniform (common case). */
+    {
+        ULONG  k;
+        ULONG *words = (ULONG *)cb->HotData;
+        ULONG  first = words[0];
+        if (first == 0 || first == 0xFFFFFFFFUL) {
+            BOOLEAN allSame = TRUE;
+            for (k = 1; k < UDF_FSBM_CHUNK_BYTES / sizeof(ULONG); k++) {
+                if (words[k] != first) { allSame = FALSE; break; }
+            }
+            cb->Chunks[cb->HotIdx].AllBits =
+                allSame ? (UCHAR)(first ? UDF_FSBM_ALLBITS_FREE : UDF_FSBM_ALLBITS_USED)
+                        : UDF_FSBM_ALLBITS_MIXED;
+        } else {
+            cb->Chunks[cb->HotIdx].AllBits = UDF_FSBM_ALLBITS_MIXED;
+        }
+    }
+#ifdef UDF_DBG
+    UDFPrint(("UDFCBMFlushHot: chunk %u: %u KB -> %u bytes AllBits=%u\n",
+              cb->HotIdx, UDF_FSBM_CHUNK_BYTES / 1024,
+              cb->Chunks[cb->HotIdx].CompressedSize,
+              (unsigned)cb->Chunks[cb->HotIdx].AllBits));
+#endif
+
     cb->HotDirty = FALSE;
     return STATUS_SUCCESS;
 } // end UDFCBMFlushHot()
@@ -5622,6 +5652,11 @@ UDFCBMGetBit(
 
     if (!cb || chunkIdx >= cb->ChunkCount)
         return FALSE;
+
+    /* Fast path: chunk is compressed and known to be uniform — no decompression. */
+    if (chunkIdx != cb->HotIdx &&
+        cb->Chunks[chunkIdx].AllBits != UDF_FSBM_ALLBITS_MIXED)
+        return (BOOLEAN)(cb->Chunks[chunkIdx].AllBits == UDF_FSBM_ALLBITS_FREE);
 
     if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
         return FALSE;
@@ -5736,6 +5771,9 @@ UDFCBMClrBitRange(
 /*
  * Return the length of the run of same-value bits starting at 'start',
  * up to (but not including) 'limit'.  Spans chunk boundaries correctly.
+ *
+ * Uniform compressed chunks (AllBits != MIXED) are handled in O(1) without
+ * any decompression.  Mixed chunks are pinned into the hot slot as before.
  */
 SIZE_T
 UDFCBMGetLen(
@@ -5744,8 +5782,9 @@ UDFCBMGetLen(
     IN ULONG limit
     )
 {
-    BOOLEAN startBit;
-    SIZE_T  len = 0;
+    BOOLEAN startBit    = FALSE;
+    BOOLEAN startBitSet = FALSE;
+    SIZE_T  len         = 0;
     ULONG   bit;
 
     if (!cb || start >= limit)
@@ -5754,37 +5793,52 @@ UDFCBMGetLen(
     limit = min(limit, cb->BitCount);
     bit   = start;
 
-    /* Determine value of the starting bit */
-    {
-        ULONG chunkIdx   = bit / UDF_FSBM_CHUNK_BITS;
-        ULONG bitInChunk = bit % UDF_FSBM_CHUNK_BITS;
-
-        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
-            return 0;
-
-        startBit = UDFGetBit((uint32*)cb->HotData, bitInChunk);
-    }
-
-    /* Extend the run chunk by chunk */
     while (bit < limit) {
         ULONG  chunkIdx       = bit / UDF_FSBM_CHUNK_BITS;
-        ULONG  bitInChunk     = bit % UDF_FSBM_CHUNK_BITS;
+        ULONG  chunkBase      = chunkIdx * UDF_FSBM_CHUNK_BITS;
         ULONG  nextChunkStart = (chunkIdx + 1) * UDF_FSBM_CHUNK_BITS;
-        ULONG  localLimit     = min(limit, nextChunkStart) - chunkIdx * UDF_FSBM_CHUNK_BITS;
+        ULONG  relCur         = bit - chunkBase;
+        ULONG  localLimit     = min(limit, nextChunkStart) - chunkBase;
         SIZE_T addLen;
 
-        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+        if (chunkIdx >= cb->ChunkCount) break;
+
+        /* Fast path: compressed uniform chunk — no decompression needed. */
+        if (chunkIdx != cb->HotIdx &&
+            cb->Chunks[chunkIdx].AllBits != UDF_FSBM_ALLBITS_MIXED) {
+            BOOLEAN chunkBit =
+                (BOOLEAN)(cb->Chunks[chunkIdx].AllBits == UDF_FSBM_ALLBITS_FREE);
+            if (!startBitSet) {
+                startBit    = chunkBit;
+                startBitSet = TRUE;
+            } else if (chunkBit != startBit) {
+                break; /* run ended at chunk boundary */
+            }
+            addLen = localLimit - relCur;
+            len   += addLen;
+            bit   += (ULONG)addLen;
+            continue;
+        }
+
+        /* Normal path: decompress (pin) the chunk. */
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx))) {
+            UDFPrint(("UDFCBMGetLen: pin failed for chunk %u; run truncated\n",
+                      chunkIdx));
             break;
+        }
 
-        /* If we've crossed into a new chunk, verify the run continues */
-        if (len > 0 && UDFGetBit((uint32*)cb->HotData, bitInChunk) != startBit)
+        if (!startBitSet) {
+            startBit    = UDFGetBit((uint32*)cb->HotData, relCur);
+            startBitSet = TRUE;
+        } else if (UDFGetBit((uint32*)cb->HotData, relCur) != startBit) {
             break;
+        }
 
-        addLen = UDFGetBitmapLen((uint32*)cb->HotData, bitInChunk, localLimit);
-        len += addLen;
-        bit += (ULONG)addLen;
+        addLen  = UDFGetBitmapLen((uint32*)cb->HotData, relCur, localLimit);
+        len    += addLen;
+        bit    += (ULONG)addLen;
 
-        /* If run ended before the chunk boundary (or hit limit), stop */
+        /* Run ended inside this chunk segment — stop. */
         if (bit < nextChunkStart || bit >= limit)
             break;
     }
@@ -5794,7 +5848,11 @@ UDFCBMGetLen(
 
 /*
  * Count bits set to 1 (free) in [startBit, endBit).
- * Uses byte-level nibble counting within each chunk.
+ *
+ * Uniform compressed chunks (AllBits != MIXED) are handled in O(1) without
+ * any decompression: all-USED contributes 0 free bits; all-FREE contributes
+ * the full byte-range width.  Mixed chunks are pinned via the hot slot.
+ * Uses a nibble lookup table for byte-level popcount.
  */
 ULONG
 UDFCBMCountFreeBits(
@@ -5818,15 +5876,35 @@ UDFCBMCountFreeBits(
         ULONG chunkIdx    = startByte / UDF_FSBM_CHUNK_BYTES;
         ULONG byteInChunk = startByte % UDF_FSBM_CHUNK_BYTES;
         ULONG endThisIter = min(endByte, (chunkIdx + 1) * UDF_FSBM_CHUNK_BYTES);
-        ULONG jEnd        = byteInChunk + (endThisIter - startByte);
-        ULONG j;
+        ULONG bytesHere   = endThisIter - startByte;
 
-        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx)))
+        if (chunkIdx >= cb->ChunkCount) break;
+
+        /* Fast path: compressed uniform chunk — no decompression needed.
+         * AllBits=USED  → 0 free bits in this range.
+         * AllBits=FREE  → bytesHere * 8 free bits (every bit is 1). */
+        if (chunkIdx != cb->HotIdx &&
+            cb->Chunks[chunkIdx].AllBits != UDF_FSBM_ALLBITS_MIXED) {
+            if (cb->Chunks[chunkIdx].AllBits == UDF_FSBM_ALLBITS_FREE)
+                count += bytesHere * 8;
+            startByte = endThisIter;
+            continue;
+        }
+
+        /* Normal path: pin and count via nibble table. */
+        if (!NT_SUCCESS(UDFCBMPinChunk(cb, chunkIdx))) {
+            UDFPrint(("UDFCBMCountFreeBits: pin failed for chunk %u; count may be low\n",
+                      chunkIdx));
             break;
+        }
 
-        for (j = byteInChunk; j < jEnd; j++) {
-            UCHAR b = (UCHAR)cb->HotData[j];
-            count += bc[b & 0xF] + bc[b >> 4];
+        {
+            ULONG jEnd = byteInChunk + bytesHere;
+            ULONG j;
+            for (j = byteInChunk; j < jEnd; j++) {
+                UCHAR b = (UCHAR)cb->HotData[j];
+                count += bc[b & 0xF] + bc[b >> 4];
+            }
         }
 
         startByte = endThisIter;
@@ -5864,14 +5942,26 @@ UDFCBMGetFlatBuf(
         start = ci * UDF_FSBM_CHUNK_BYTES;
         bytes = min(UDF_FSBM_CHUNK_BYTES, cb->ByteCount - start);
 
-        if (cb->Chunks[ci].CompressedData == NULL) {
-            RtlZeroMemory(flat + start, bytes);
-        } else if (cb->Chunks[ci].CompressedSize == 0) {
+        /* Fast path: uniform chunks need no decompression at all. */
+        if (cb->Chunks[ci].CompressedData == NULL ||
+            (ci != cb->HotIdx &&
+             cb->Chunks[ci].AllBits != UDF_FSBM_ALLBITS_MIXED)) {
+            if (cb->Chunks[ci].CompressedData == NULL ||
+                cb->Chunks[ci].AllBits == UDF_FSBM_ALLBITS_USED) {
+                /* NULL CompressedData → all-zero initial state (all USED) */
+                RtlZeroMemory(flat + start, bytes);
+            } else {
+                /* AllBits == FREE → every bit is 1 */
+                RtlFillMemory(flat + start, bytes, 0xFF);
+            }
+            continue;
+        }
+
+        if (cb->Chunks[ci].CompressedSize == 0) {
+            /* Stored verbatim (uncompressed) */
             RtlCopyMemory(flat + start, cb->Chunks[ci].CompressedData, bytes);
         } else {
-            /* Decompress into the hot buffer, then copy the valid bytes.
-             * On failure, free the partial flat buffer and return NULL so
-             * the caller knows it cannot safely use the result. */
+            /* LZNT1 compressed: decompress into the hot buffer, then copy. */
             NTSTATUS decompSt;
             finalSize = 0;
             decompSt = RtlDecompressBuffer(
@@ -5929,10 +6019,36 @@ UDFCBMFromFlat(
         if (bytes < UDF_FSBM_CHUNK_BYTES)
             RtlZeroMemory(cb->HotData + bytes, UDF_FSBM_CHUNK_BYTES - bytes);
 
-        /* Compress and store */
-        UDFCompressBitmap(cb->HotData, UDF_FSBM_CHUNK_BYTES,
-                          &cb->Chunks[ci].CompressedData,
-                          &cb->Chunks[ci].CompressedSize);
+        /* Compress and store, then compute AllBits hint from the live data.
+         * On failure, CompressedData stays NULL (treated as all-USED), which
+         * is safe but conservative. */
+        {
+            NTSTATUS compSt = UDFCompressBitmap(cb->HotData, UDF_FSBM_CHUNK_BYTES,
+                                                &cb->Chunks[ci].CompressedData,
+                                                &cb->Chunks[ci].CompressedSize);
+            if (!NT_SUCCESS(compSt)) {
+                UDFPrint(("UDFCBMFromFlat: compress failed for chunk %u: 0x%08X; "
+                          "treating as all-USED\n", ci, compSt));
+                cb->Chunks[ci].AllBits = UDF_FSBM_ALLBITS_USED;
+                continue;
+            }
+        }
+        {
+            ULONG  k;
+            ULONG *words = (ULONG *)cb->HotData;
+            ULONG  first = words[0];
+            if (first == 0 || first == 0xFFFFFFFFUL) {
+                BOOLEAN allSame = TRUE;
+                for (k = 1; k < UDF_FSBM_CHUNK_BYTES / sizeof(ULONG); k++) {
+                    if (words[k] != first) { allSame = FALSE; break; }
+                }
+                cb->Chunks[ci].AllBits =
+                    allSame ? (UCHAR)(first ? UDF_FSBM_ALLBITS_FREE : UDF_FSBM_ALLBITS_USED)
+                            : UDF_FSBM_ALLBITS_MIXED;
+            } else {
+                cb->Chunks[ci].AllBits = UDF_FSBM_ALLBITS_MIXED;
+            }
+        }
     }
 
     /* Last chunk's data is still in HotData but we won't track it as hot

--- a/drivers/filesystems/udfs/udf_info/udf_info.cpp
+++ b/drivers/filesystems/udfs/udf_info/udf_info.cpp
@@ -5348,8 +5348,8 @@ UDFCompressBitmap(
     DbgFreePool(workSpace);
 
     if (!NT_SUCCESS(status) || finalSize >= UncompressedSize) {
-        // Compression didn't help or failed; store uncompressed copy in the
-        // existing buffer to avoid a free/allocate cycle
+        // Compression didn't help (result >= input) or failed.
+        // Store a verbatim copy; CompressedSize = 0 signals "uncompressed".
         RtlCopyMemory(compBuf, UncompressedData, UncompressedSize);
         *CompressedBuffer = compBuf;
         *CompressedSize = 0; // 0 signals "stored uncompressed"
@@ -5590,6 +5590,10 @@ UDFCBMPinChunk(
                 cb->Chunks[chunkIdx].CompressedSize,
                 &finalSize);
         if (!NT_SUCCESS(st)) {
+            /* Zeroing marks all sectors in this chunk as USED (bit=0), which
+             * prevents allocations from an unreadable chunk and is safer than
+             * returning an error and leaving the hot buffer in an undefined
+             * state. */
             UDFPrint(("UDFCBMPinChunk: decompress failed 0x%08X, zeroing chunk %u\n",
                       st, chunkIdx));
             RtlZeroMemory(cb->HotData, UDF_FSBM_CHUNK_BYTES);
@@ -5865,14 +5869,25 @@ UDFCBMGetFlatBuf(
         } else if (cb->Chunks[ci].CompressedSize == 0) {
             RtlCopyMemory(flat + start, cb->Chunks[ci].CompressedData, bytes);
         } else {
-            /* Decompress into the hot buffer, then copy the valid bytes */
+            /* Decompress into the hot buffer, then copy the valid bytes.
+             * On failure, free the partial flat buffer and return NULL so
+             * the caller knows it cannot safely use the result. */
+            NTSTATUS decompSt;
             finalSize = 0;
-            RtlDecompressBuffer(
+            decompSt = RtlDecompressBuffer(
                 COMPRESSION_FORMAT_LZNT1,
                 (PUCHAR)cb->HotData, UDF_FSBM_CHUNK_BYTES,
                 (PUCHAR)cb->Chunks[ci].CompressedData,
                 cb->Chunks[ci].CompressedSize,
                 &finalSize);
+            if (!NT_SUCCESS(decompSt)) {
+                UDFPrint(("UDFCBMGetFlatBuf: decompress chunk %u failed 0x%08X\n",
+                          ci, decompSt));
+                DbgFreePool(flat);
+                cb->HotIdx   = UDF_FSBM_NO_HOT_CHUNK;
+                cb->HotDirty = FALSE;
+                return NULL;
+            }
             RtlCopyMemory(flat + start, cb->HotData, bytes);
         }
     }

--- a/drivers/filesystems/udfs/udf_info/udf_info.h
+++ b/drivers/filesystems/udfs/udf_info/udf_info.h
@@ -1473,4 +1473,23 @@ UDFDecompressBitmap(
     OUT PCHAR *DecompressedBuffer
     );
 
+/* --- Chunked Compressed Free-Space Bitmap (CBM) API ------------------------- */
+
+PUDF_CHUNKED_FSBM UDFCBMCreate(IN ULONG BitCount);
+VOID              UDFCBMDestroy(IN PUDF_CHUNKED_FSBM cb);
+NTSTATUS          UDFCBMFlushHot(IN PUDF_CHUNKED_FSBM cb);
+NTSTATUS          UDFCBMPinChunk(IN PUDF_CHUNKED_FSBM cb, IN ULONG chunkIdx);
+BOOLEAN           UDFCBMGetBit(IN PUDF_CHUNKED_FSBM cb, IN ULONG bit);
+VOID              UDFCBMSetBit(IN PUDF_CHUNKED_FSBM cb, IN ULONG bit);
+VOID              UDFCBMClrBit(IN PUDF_CHUNKED_FSBM cb, IN ULONG bit);
+VOID              UDFCBMSetBitRange(IN PUDF_CHUNKED_FSBM cb, IN ULONG startBit, IN ULONG count);
+VOID              UDFCBMClrBitRange(IN PUDF_CHUNKED_FSBM cb, IN ULONG startBit, IN ULONG count);
+SIZE_T            UDFCBMGetLen(IN PUDF_CHUNKED_FSBM cb, IN ULONG start, IN ULONG limit);
+ULONG             UDFCBMCountFreeBits(IN PUDF_CHUNKED_FSBM cb, IN ULONG startBit, IN ULONG endBit);
+PCHAR             UDFCBMGetFlatBuf(IN PUDF_CHUNKED_FSBM cb);
+PUDF_CHUNKED_FSBM UDFCBMFromFlat(IN PCHAR flat, IN ULONG byteCount);
+VOID              UDFCBMApplyBSBM(IN PUDF_CHUNKED_FSBM cb, IN PCHAR bsbm, IN ULONG lba, IN ULONG len);
+
+/* ----------------------------------------------------------------------------- */
+
 #endif // __UDF_STRUCT_SUPPORT_H__

--- a/drivers/filesystems/udfs/udf_info/udf_info.h
+++ b/drivers/filesystems/udfs/udf_info/udf_info.h
@@ -1457,4 +1457,20 @@ UDFCheckArea(
     IN uint32 BCount
     );
 
+NTSTATUS
+UDFCompressBitmap(
+    IN PCHAR  UncompressedData,
+    IN ULONG  UncompressedSize,
+    OUT PCHAR *CompressedBuffer,
+    OUT ULONG *CompressedSize
+    );
+
+NTSTATUS
+UDFDecompressBitmap(
+    IN PCHAR  CompressedData,
+    IN ULONG  CompressedSize,
+    IN ULONG  UncompressedSize,
+    OUT PCHAR *DecompressedBuffer
+    );
+
 #endif // __UDF_STRUCT_SUPPORT_H__


### PR DESCRIPTION
A 256 GB UDF volume requires a 16 MB flat free-space bitmap held entirely in NonPagedPool. This replaces it with 64 KB LZNT1-compressed chunks (~1 MB at rest) and adds a zero-decompression fast-path for uniform chunks, retaining `RtlCompressBuffer`/`RtlDecompressBuffer` over a custom RLE scheme — benchmarks show LZNT1 is faster at the relevant I/O sizes.

## New chunked bitmap (`FSBM_Chunks`)

- `VCB.FSBM_Bitmap` (flat `PCHAR`) → `VCB.FSBM_Chunks` (`PUDF_CHUNKED_FSBM`)
- `UDF_CHUNKED_FSBM`: array of `UDF_FSBM_CHUNK` descriptors + one 64 KB hot-slot buffer
- Each chunk: `CompressedData` (LZNT1 or verbatim), `CompressedSize` (0 = verbatim, >0 = LZNT1), `AllBits` hint
- All call sites updated across `alloc.cpp`, `mount.cpp`, `udf_info.cpp`, `extent.cpp`, `dirtree.cpp`, `fscntrl.cpp`

## `AllBits` uniform-chunk fast-path

Ported from PR #6. Avoids decompression entirely when every bit in a chunk is the same value.

```c
// UDF_FSBM_CHUNK::AllBits
#define UDF_FSBM_ALLBITS_USED   0x00  // NULL CompressedData initial state
#define UDF_FSBM_ALLBITS_FREE   0x01
#define UDF_FSBM_ALLBITS_MIXED  0x02  // must decompress
```

Set in `UDFCBMFlushHot` and `UDFCBMFromFlat` by inspecting `words[0]`; only scans the full chunk when the first word is uniform (common case). Consumed in:

- **`UDFCBMGetBit`** — single-branch return, no pin
- **`UDFCBMGetLen`** (restructured) — entire chunk range consumed O(1); the free-space scan in `UDFFindMinSuitableExtent` skips hundreds of decompressions on a freshly-mounted volume where most chunks are all-USED
- **`UDFCBMCountFreeBits`** — all-USED adds 0, all-FREE adds `bytesHere × 8`
- **`UDFCBMGetFlatBuf`** — `RtlZeroMemory` / `RtlFillMemory(0xFF)` instead of decompressing

## `UDFGetBitmapLen` buffer-overread fix

When the bit-limit is an exact multiple of 32, `lLim == 0` and the old loop read one word past the end of the bitmap buffer. Added guard:

```c
if (i > Lim || (i == Lim && !lLim)) break;
```

## Memory profile

| Volume | Flat bitmap | Chunked (est.) |
|---|---|---|
| 256 GB / 2 KB sectors | 16 MB | ~1 MB (256 × ~4 KB compressed) + 64 KB hot buffer |

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>[UDFS] Use RTLCompressBuffer and RTLDecompressBuffer to compress/decompress bitmaps to help UDF drives work under low RAM machines/VMs</issue_title>
> <issue_description></issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Zero3K20/reactos-udfs#3

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.