### PR TITLE
Move large flat bitmap allocations to PagedPool in UDFS driver

### DIFF
--- a/drivers/filesystems/udfs/Include/phys_lib.cpp
+++ b/drivers/filesystems/udfs/Include/phys_lib.cpp
@@ -718,7 +718,7 @@ UDFDetermineVolumeLayout(
         // be unreadable. We should forget about them, because UDF needs
         // last _readable_ sector.
 
-        TempBuffer = MyAllocatePool__(NonPagedPool, Vcb->SectorSize);
+        TempBuffer = MyAllocatePool__(PagedPool, Vcb->SectorSize);
 
         if (!TempBuffer) { 
             return STATUS_INSUFFICIENT_RESOURCES;
@@ -1066,7 +1066,7 @@ UDFReadInSector(
         return STATUS_INVALID_PARAMETER;
     }
 
-    tmp_buff = (int8*)MyAllocatePool__(NonPagedPool, Vcb->SectorSize);
+    tmp_buff = (int8*)MyAllocatePool__(PagedPool, Vcb->SectorSize);
     if (!tmp_buff) return STATUS_INSUFFICIENT_RESOURCES;
     status = UDFReadSectors(IrpContext, Vcb, Translate, Lba, 1, FALSE, tmp_buff, &_ReadBytes);
     if (NT_SUCCESS(status)) {
@@ -1209,7 +1209,7 @@ UDFWriteInSector(
         BrutePoint();
         return STATUS_INVALID_PARAMETER;
     }
-    tmp_buff = (int8*)MyAllocatePool__(NonPagedPool, Vcb->SectorSize);
+    tmp_buff = (int8*)MyAllocatePool__(PagedPool, Vcb->SectorSize);
     if (!tmp_buff) {
         BrutePoint();
         return STATUS_INSUFFICIENT_RESOURCES;

--- a/drivers/filesystems/udfs/udf_info/alloc.cpp
+++ b/drivers/filesystems/udfs/udf_info/alloc.cpp
@@ -411,8 +411,8 @@ UDFCheckSpaceAllocation_(
 
     if (!Map) return;
 
-    BS = Vcb->BlockSize;
-    BSh = Vcb->BlockSizeBits;
+    BS = Vcb->SectorSize;
+    BSh = Vcb->SectorShift;
 
     UDFAcquireResourceShared(&(Vcb->BitMapResource1),TRUE);
     // walk through all frags in data area specified
@@ -570,7 +570,7 @@ UDFMarkSpaceAsXXXNoProtect_(
         AdPrint(("Alloc:%x:%s:%x:@:%x:File:%x:Line:%d\n",
             FE_lba,
             asUsed ? ((asXXX & AS_BAD) ? "B" : "U") : "F",
-            (Map[i].extLength & UDF_EXTENT_LENGTH_MASK) >> Vcb->BlockSizeBits,
+            (Map[i].extLength & UDF_EXTENT_LENGTH_MASK) >> Vcb->SectorShift,
             Map[i].extLocation,
             BugCheckId,
             Line

--- a/drivers/filesystems/udfs/udf_info/extent.cpp
+++ b/drivers/filesystems/udfs/udf_info/extent.cpp
@@ -396,7 +396,7 @@ UDFShortAllocDescToMapping(
         }
         else {
 #ifdef UDF_CHECK_EXTENT_SIZE_ALIGNMENT
-            ASSERT(!(len & (Vcb->LBlockSize-1) ));
+            ASSERT(!(len & (Vcb->SectorSize-1) ));
 #endif //UDF_CHECK_EXTENT_SIZE_ALIGNMENT
             if (len & (Vcb->SectorSize-1)) {
                 w2k_compat = TRUE;
@@ -693,7 +693,7 @@ UDFExtAllocDescToMapping(
         }*/
         Extent[i].extLength = len;
 #ifdef UDF_CHECK_EXTENT_SIZE_ALIGNMENT
-        ASSERT(!(len & (Vcb->LBlockSize-1) ));
+        ASSERT(!(len & (Vcb->SectorSize-1) ));
 #endif //UDF_CHECK_EXTENT_SIZE_ALIGNMENT
         // Note: for compatibility Adaptec DirectCD we check 'len' here
         //       That strange implementation records bogus extLocation in terminal entries
@@ -1198,8 +1198,8 @@ UDFBuildExtAllocDescs(
     uint32 i, j;
     uint32 len=0, ac, len2;
     uint32 TagLoc, prevTagLoc;
-    uint32 LBS = Vcb->LBlockSize;
-    uint32 LBSh = Vcb->BlockSizeBits;
+    uint32 LBS = Vcb->SectorSize;
+    uint32 LBSh = Vcb->SectorShift;
     PEXTENT_MAP Extent = FileInfo->Dloc->DataLoc.Mapping;
     PEXTENT_INFO AllocExtent = &(FileInfo->Dloc->AllocLoc);
     PEXT_AD Alloc, saved_Alloc;
@@ -2952,7 +2952,7 @@ UDFReadExtentCached(
         to_read = (to_read < Length) ?
                    to_read : Length;
         if (flags == EXTENT_RECORDED_ALLOCATED) {
-            status = UDFReadDataCached(Vcb, TRUE, ( ((uint64)Lba) << Vcb->BlockSizeBits) + sect_offs, to_read, Buffer, &_ReadBytes);
+            status = UDFReadDataCached(Vcb, TRUE, ( ((uint64)Lba) << Vcb->SectorShift) + sect_offs, to_read, Buffer, &_ReadBytes);
             (*ReadBytes) += _ReadBytes;
         } else {
             RtlZeroMemory(Buffer, to_read);

--- a/drivers/filesystems/udfs/udf_info/mount.cpp
+++ b/drivers/filesystems/udfs/udf_info/mount.cpp
@@ -81,7 +81,7 @@ UDFPrepareXSpaceBitmap(
     LBS = Vcb->SectorSize;
 
     *XSl = sizeof(SPACE_BITMAP_DESC) + ((plen+7)>>3);
-    _XSBM = (int8*)DbgAllocatePool(NonPagedPool, (*XSl + BS - 1) & ~(BS-1) );
+    _XSBM = (int8*)DbgAllocatePool(PagedPool, (*XSl + BS - 1) & ~(BS-1) );
     *XSBM = _XSBM;
 
     switch (XSpaceBitmap->extLength >> 30) {
@@ -350,7 +350,7 @@ UDFUpdateUSpaceDesc(
 
     usd = (PUNALLOC_SPACE_DESC)Buf;
     usd->numAllocDescs = 0;
-    RtlZeroMemory(Buf+sizeof(UNALLOC_SPACE_DESC), Vcb->BlockSize - sizeof(UNALLOC_SPACE_DESC));
+    RtlZeroMemory(Buf+sizeof(UNALLOC_SPACE_DESC), Vcb->SectorSize - sizeof(UNALLOC_SPACE_DESC));
     UDFSetUpTag(Vcb, &(usd->descTag), 0, usd->descTag.tagLocation);
     UDFWriteSectors(Vcb, TRUE, usd->descTag.tagLocation, 1, FALSE, Buf, &WrittenBytes);
     return STATUS_SUCCESS;
@@ -703,7 +703,7 @@ UDFUpdateVDS(
             status = UDFReadTagged(Vcb, Buf, vds[i].block, vds[i].block, &ident);
             if (NT_SUCCESS(status) && (i == VDS_POS_PARTITION_DESC)) {
                 // load partition descriptor(s)
-                int8*  Buf2 = (int8*)DbgAllocatePool(NonPagedPool,Vcb->BlockSize);
+                int8*  Buf2 = (int8*)DbgAllocatePool(NonPagedPool,Vcb->SectorSize);
                 if (!Buf2) {
                     DbgFreePool(Buf);
                     return STATUS_INSUFFICIENT_RESOURCES;
@@ -1643,7 +1643,7 @@ UDFAddXSpaceBitmap(
     i=UDFPartStart(Vcb, RefPartNum);
     flags = bm->extLength >> 30;
     if (!flags /*|| flags == EXTENT_NOT_RECORDED_ALLOCATED*/) {
-        tmp = (int8*)DbgAllocatePool(NonPagedPool, max(Length, Vcb->SectorSize));
+        tmp = (int8*)DbgAllocatePool(PagedPool, max(Length, Vcb->SectorSize));
         if (!tmp) return STATUS_INSUFFICIENT_RESOURCES;
         locAddr.partitionReferenceNum = (uint16)RefPartNum;
         locAddr.logicalBlockNum = bm->extPosition;
@@ -1723,7 +1723,7 @@ UDFVerifyXSpaceBitmap(
 //    i=UDFPartStart(Vcb, RefPartNum);
     flags = bm->extLength >> 30;
     if (!flags /*|| flags == EXTENT_NOT_RECORDED_ALLOCATED*/) {
-        tmp = (int8*)DbgAllocatePool(NonPagedPool, max(Length, Vcb->SectorSize));
+        tmp = (int8*)DbgAllocatePool(PagedPool, max(Length, Vcb->SectorSize));
         if (!tmp) return STATUS_INSUFFICIENT_RESOURCES;
         locAddr.partitionReferenceNum = (uint16)RefPartNum;
         locAddr.logicalBlockNum = bm->extPosition;
@@ -1823,7 +1823,7 @@ UDFDelXSpaceBitmap(
             MyFreePool__(tmp);
             return status;
         }
-        if (!NT_SUCCESS(status = UDFReadData(Vcb, FALSE, ((uint64)j)<<Vcb->BlockSizeBits, Length, FALSE, tmp, &ReadBytes))) {
+        if (!NT_SUCCESS(status = UDFReadData(Vcb, FALSE, ((uint64)j)<<Vcb->SectorShift, Length, FALSE, tmp, &ReadBytes))) {
             MyFreePool__(tmp);
             return status;
         }
@@ -1964,13 +1964,13 @@ UDFBuildFreeSpaceBitmap(
 
     if (!(Vcb->FSBM_Bitmap)) {
         // init Bitmap buffer if necessary
-        Vcb->FSBM_Bitmap = (int8*)DbgAllocatePool(NonPagedPool, (i = (Vcb->LastPossibleLBA+1+7)>>3) );
+        Vcb->FSBM_Bitmap = (int8*)DbgAllocatePool(PagedPool, (i = (Vcb->LastPossibleLBA+1+7)>>3) );
         if (!(Vcb->FSBM_Bitmap)) return STATUS_INSUFFICIENT_RESOURCES;
 
         RtlZeroMemory(Vcb->FSBM_Bitmap, i);
 
 #ifdef UDF_TRACK_ONDISK_ALLOCATION_OWNERS
-        Vcb->FSBM_Bitmap_owners = (uint32*)DbgAllocatePool(NonPagedPool, (Vcb->LastPossibleLBA+1)*sizeof(uint32));
+        Vcb->FSBM_Bitmap_owners = (uint32*)DbgAllocatePool(PagedPool, (Vcb->LastPossibleLBA+1)*sizeof(uint32));
         if (!(Vcb->FSBM_Bitmap_owners)) {
             MyFreePool__(Vcb->ZSBM_Bitmap);
             Vcb->ZSBM_Bitmap = NULL;
@@ -2964,7 +2964,7 @@ UDFGetDiskInfoAndVerify(
 
         UDFLoadFileset(Vcb,FileSetDesc, &(Vcb->RootLbAddr), &(Vcb->SysStreamLbAddr));
 
-        Vcb->FSBM_OldBitmap = (int8*)DbgAllocatePool(NonPagedPool, Vcb->FSBM_ByteCount);
+        Vcb->FSBM_OldBitmap = (int8*)DbgAllocatePool(PagedPool, Vcb->FSBM_ByteCount);
         if (!(Vcb->FSBM_OldBitmap)) try_return(RC = STATUS_INSUFFICIENT_RESOURCES);
         RtlCopyMemory(Vcb->FSBM_OldBitmap, Vcb->FSBM_Bitmap, Vcb->FSBM_ByteCount);
 

--- a/drivers/filesystems/udfs/udf_info/udf_info.cpp
+++ b/drivers/filesystems/udfs/udf_info/udf_info.cpp
@@ -3698,7 +3698,7 @@ err_vat_15:
         goto err_vat_15;
     }
     // read VAT & remember old version
-    Vcb->Vat = (uint32*)DbgAllocatePool(NonPagedPool, (Vcb->LastPossibleLBA+1)*sizeof(uint32) );
+    Vcb->Vat = (uint32*)DbgAllocatePool(PagedPool, (Vcb->LastPossibleLBA+1)*sizeof(uint32) );
     if (!Vcb->Vat) {
         goto err_vat_15_2;
     }
@@ -3777,7 +3777,7 @@ UDFReadFileEA(
     if (FileDirNdx->FileInfo) {
         FileEntry = (PFILE_ENTRY)(FileDirNdx->FileInfo->Dloc->FileEntry);
     } else {
-        FileEntry = (PFILE_ENTRY)MyAllocatePool__(NonPagedPool, Vcb->BlockSize);
+        FileEntry = (PFILE_ENTRY)MyAllocatePool__(NonPagedPool, Vcb->SectorSize);
         if (!FileEntry) return;
         if (!NT_SUCCESS(status = UDFReadFileEntry(Vcb, &(FileDirNdx->FileEntry), FileEntry, &Ident))) {
             MyFreePool__(FileEntry);


### PR DESCRIPTION
This allows it to mount 256 GB (and possibly larger) drives under ReactOS/Windows Server 2003/etc.